### PR TITLE
🧪 Add tests for invalid PDF conversion in streamtools

### DIFF
--- a/tests/unit/TestRunner.lpi
+++ b/tests/unit/TestRunner.lpi
@@ -68,6 +68,10 @@
         <Filename Value="TestNFSe.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit>
+      <Unit>
+        <Filename Value="TestStreamTools.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/tests/unit/TestRunner.lpr
+++ b/tests/unit/TestRunner.lpr
@@ -3,7 +3,7 @@ program TestRunner;
 {$mode objfpc}{$H+}
 
 uses
-  Classes, consoletestrunner, TestCTe, TestNFe, TestMDFe, TestDiversos, TestCertificados, TestNFSe;
+  Classes, consoletestrunner, TestCTe, TestNFe, TestMDFe, TestDiversos, TestCertificados, TestNFSe, TestStreamTools;
 
 type
   TMyTestRunner = class(consoletestrunner.TTestRunner)

--- a/tests/unit/TestStreamTools.pas
+++ b/tests/unit/TestStreamTools.pas
@@ -1,0 +1,110 @@
+unit TestStreamTools;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, fpcunit, testutils, testregistry, streamtools;
+
+type
+
+  { TTestStreamTools }
+
+  TTestStreamTools = class(TTestCase)
+  published
+    procedure TestFileToStringBase64_EmptyFile;
+    procedure TestFileToStringBase64_EmptyFile_Delete;
+    procedure TestFileToStringBase64_ValidFile;
+  end;
+
+implementation
+
+{ TTestStreamTools }
+
+procedure TTestStreamTools.TestFileToStringBase64_EmptyFile;
+var
+  TempFile: string;
+  Size: Integer;
+begin
+  TempFile := 'empty_test_file_nodelete.pdf';
+  // Create an empty file
+  with TFileStream.Create(TempFile, fmCreate) do
+    Free;
+
+  try
+    try
+      FileToStringBase64(TempFile, False, Size);
+      Fail('Should have raised an exception for empty file');
+    except
+      on E: Exception do
+        AssertEquals('O arquivo gerado não parece ser válido.', E.Message);
+    end;
+    // Since Apagar was false, file should still exist
+    AssertTrue('File should still exist', FileExists(TempFile));
+  finally
+    if FileExists(TempFile) then
+      DeleteFile(TempFile);
+  end;
+end;
+
+procedure TTestStreamTools.TestFileToStringBase64_EmptyFile_Delete;
+var
+  TempFile: string;
+  Size: Integer;
+begin
+  TempFile := 'empty_test_file_delete.pdf';
+  // Create an empty file
+  with TFileStream.Create(TempFile, fmCreate) do
+    Free;
+
+  try
+    try
+      FileToStringBase64(TempFile, True, Size);
+      Fail('Should have raised an exception for empty file');
+    except
+      on E: Exception do
+      begin
+        AssertEquals('O arquivo gerado não parece ser válido.', E.Message);
+        // Since Apagar was true, file should be deleted even if exception occurs
+        AssertFalse('File should have been deleted', FileExists(TempFile));
+      end;
+    end;
+  finally
+    if FileExists(TempFile) then
+      DeleteFile(TempFile);
+  end;
+end;
+
+procedure TTestStreamTools.TestFileToStringBase64_ValidFile;
+var
+  TempFile: string;
+  Size: Integer;
+  ResultStr: string;
+  FS: TFileStream;
+  TestData: string;
+begin
+  TempFile := 'valid_test_file.txt';
+  TestData := 'Hello World';
+  FS := TFileStream.Create(TempFile, fmCreate);
+  try
+    FS.WriteBuffer(TestData[1], Length(TestData));
+  finally
+    FS.Free;
+  end;
+
+  try
+    ResultStr := FileToStringBase64(TempFile, True, Size);
+    AssertEquals('Size should match', Length(TestData), Size);
+    // 'Hello World' in Base64 is 'SGVsbG8gV29ybGQ='
+    AssertEquals('Base64 content mismatch', 'SGVsbG8gV29ybGQ=', ResultStr);
+    AssertFalse('File should have been deleted', FileExists(TempFile));
+  finally
+    if FileExists(TempFile) then
+      DeleteFile(TempFile);
+  end;
+end;
+
+initialization
+  RegisterTest(TTestStreamTools);
+end.


### PR DESCRIPTION
The testing gap addressed was the missing error test for invalid PDF file conversion in `tools/streamtools.pas`.

The new tests cover the following scenarios:
1.  **Empty file exception:** Verifies that a zero-byte file raises the expected exception.
2.  **File deletion on error:** Verifies that when the `Apagar` flag is set, the temporary file is deleted even if an exception is raised due to the file being empty.
3.  **Happy path conversion:** Verifies that a valid file is correctly converted to Base64 and the file is deleted as requested.

The improvements increase the test coverage for the utility functions in `streamtools.pas` and ensure that the error handling logic behaves as expected, including resource cleanup.

---
*PR created automatically by Jules for task [18015506558622335778](https://jules.google.com/task/18015506558622335778) started by @macgayverarmini*