### PR TITLE
Fix and refactor CT-e and MDF-e OpenAPI endpoints

### DIFF
--- a/resources/resource.strings.routes.pas
+++ b/resources/resource.strings.routes.pas
@@ -44,8 +44,8 @@ resourcestring
   RSModeloCTeCTeToXMLRoute = '/modelo/cte/cte-to-xml';
   RSCTeEventosRoute = '/cte/eventos';
   RSCTeDistribuicaoRoute = '/cte/distribuicao';
-  RSCTeDANFeRoute = '/cte/danfe';
-  RSCTeNFeRoute = '/cte/nfe';
+  RSCTeDACTERoute = '/cte/dacte';
+  RSCTeCTeRoute = '/cte/cte';
   RSCTeStatusRoute = '/cte/status';
   RSCTeConsultaRoute = '/cte/consulta';
   RSCTeInutilizacaoRoute = '/cte/inutilizacao';
@@ -80,7 +80,7 @@ resourcestring
   RSModeloMDFeEventoRoute = '/modelo/mdfe/evento';
   RSModeloMDFeMDFeRoute = '/modelo/mdfe/mdfe';
   RSModeloMDFeDistribuicaoRoute = '/modelo/mdfe/distribuicao';
-  RSMDFeEnviarRoute = '/mdfe/enviar';
+  RSMDFeMDFeRoute = '/mdfe/mdfe';
   RSMDFeEventosRoute = '/mdfe/eventos';
   RSMDFeDAMDFeRoute = '/mdfe/damdfe';
   RSMDFeDistribuicaoRoute = '/mdfe/distribuicao';

--- a/routes/route.acbr.cte.pas
+++ b/routes/route.acbr.cte.pas
@@ -394,8 +394,8 @@ begin
   THorse.Post(RSCTeConsultaRoute, PostConsulta);
   THorse.Post(RSCTeInutilizacaoRoute, PostInutilizacao);
   THorse.Post(RSCTeDistribuicaoRoute, PostDistCTe);
-  THorse.Post(RSCTeDANFeRoute, PostDACTE);
-  THorse.Post(RSCTeNFeRoute, PostCTe);
+  THorse.Post(RSCTeDACTERoute, PostDACTE);
+  THorse.Post(RSCTeCTeRoute, PostCTe);
   THorse.Post(RSCTeCancelamentoRoute, PostCancelamento);
   THorse.Post(RSCTeCTeFromXMLRoute, PostCTeFromXML);
   THorse.Post(RSCTeCTeToXMLRoute, PostCTeToXML);

--- a/routes/route.acbr.mdfe.pas
+++ b/routes/route.acbr.mdfe.pas
@@ -8,7 +8,8 @@ uses
   // Unit com a lógica de negócio do MDF-e
   method.acbr.mdfe,
   // Units do Horse e JSON
-  fpjson, Horse, Horse.Commons, Classes, SysUtils;
+  fpjson, Horse, Horse.Commons, Classes, SysUtils,
+  resource.strings.routes;
 
 // --- Handlers para Endpoints de Modelos (GET) ---
 procedure GetModeloConfigMDFe(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
@@ -181,16 +182,16 @@ end;
 procedure regRouter;
 begin
   // Endpoints de Modelos (GET)
-  THorse.Get('/modelo/mdfe/config', GetModeloConfigMDFe);
-  THorse.Get('/modelo/mdfe/evento', GetModeloEventoMDFe);
-  THorse.Get('/modelo/mdfe/mdfe', GetModeloMDFe);
-  THorse.Get('/modelo/mdfe/distribuicao', GetModeloDistribuicaoMDFe);
+  THorse.Get(RSModeloMDFeConfigRoute, GetModeloConfigMDFe);
+  THorse.Get(RSModeloMDFeEventoRoute, GetModeloEventoMDFe);
+  THorse.Get(RSModeloMDFeMDFeRoute, GetModeloMDFe);
+  THorse.Get(RSModeloMDFeDistribuicaoRoute, GetModeloDistribuicaoMDFe);
 
   // Endpoints de Operações (POST)
-  THorse.Post('/mdfe/enviar', PostEnviarMDFe);
-  THorse.Post('/mdfe/eventos', PostEventosMDFe);
-  THorse.Post('/mdfe/damdfe', PostDamdfeMDFe);
-  THorse.Post('/mdfe/distribuicao', PostDistribuicaoMDFe);
+  THorse.Post(RSMDFeMDFeRoute, PostEnviarMDFe);
+  THorse.Post(RSMDFeEventosRoute, PostEventosMDFe);
+  THorse.Post(RSMDFeDAMDFeRoute, PostDamdfeMDFe);
+  THorse.Post(RSMDFeDistribuicaoRoute, PostDistribuicaoMDFe);
 end;
 
 end.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -127,6 +127,30 @@ paths:
               type: object
               description: Para saber o formato exato, chame o endpoint GET correspondente
                 (se disponível) para obter o modelo JSON.
+  /cte/cte:
+    post:
+      tags:
+      - CTe
+      summary: Operação Cte
+      description: Executa a operação usando o payload JSON.
+      responses:
+        '200':
+          description: Sucesso
+          content:
+            application/json: {}
+        '400':
+          description: 'Erro na requisição (ex: JSON inválido)'
+          content:
+            application/json: {}
+      requestBody:
+        description: Payload em formato JSON
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Para saber o formato exato, chame o endpoint GET correspondente
+                (se disponível) para obter o modelo JSON.
   /cte/cte-from-xml:
     post:
       tags:
@@ -175,11 +199,11 @@ paths:
               type: object
               description: Para saber o formato exato, chame o endpoint GET correspondente
                 (se disponível) para obter o modelo JSON.
-  /cte/dacte-evento:
+  /cte/dacte:
     post:
       tags:
       - CTe
-      summary: Operação Dacte Evento
+      summary: Operação Dacte
       description: Executa a operação usando o payload JSON.
       responses:
         '200':
@@ -199,11 +223,11 @@ paths:
               type: object
               description: Para saber o formato exato, chame o endpoint GET correspondente
                 (se disponível) para obter o modelo JSON.
-  /cte/danfe:
+  /cte/dacte-evento:
     post:
       tags:
       - CTe
-      summary: Operação Danfe
+      summary: Operação Dacte Evento
       description: Executa a operação usando o payload JSON.
       responses:
         '200':
@@ -276,30 +300,6 @@ paths:
       tags:
       - CTe
       summary: Operação Inutilizacao
-      description: Executa a operação usando o payload JSON.
-      responses:
-        '200':
-          description: Sucesso
-          content:
-            application/json: {}
-        '400':
-          description: 'Erro na requisição (ex: JSON inválido)'
-          content:
-            application/json: {}
-      requestBody:
-        description: Payload em formato JSON
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Para saber o formato exato, chame o endpoint GET correspondente
-                (se disponível) para obter o modelo JSON.
-  /cte/nfe:
-    post:
-      tags:
-      - CTe
-      summary: Operação Nfe
       description: Executa a operação usando o payload JSON.
       responses:
         '200':
@@ -445,11 +445,11 @@ paths:
               type: object
               description: Para saber o formato exato, chame o endpoint GET correspondente
                 (se disponível) para obter o modelo JSON.
-  /mdfe/enviar:
+  /mdfe/eventos:
     post:
       tags:
       - MDFe
-      summary: Operação Enviar
+      summary: Operação Eventos
       description: Executa a operação usando o payload JSON.
       responses:
         '200':
@@ -469,11 +469,11 @@ paths:
               type: object
               description: Para saber o formato exato, chame o endpoint GET correspondente
                 (se disponível) para obter o modelo JSON.
-  /mdfe/eventos:
+  /mdfe/mdfe:
     post:
       tags:
       - MDFe
-      summary: Operação Eventos
+      summary: Operação Mdfe
       description: Executa a operação usando o payload JSON.
       responses:
         '200':

--- a/tests/unit/TestCTe.pas
+++ b/tests/unit/TestCTe.pas
@@ -232,7 +232,7 @@ begin
        Json.Add('config', CreateConfigJSON);
        // Needs 'cte' object usually
        Client.RequestBody := TStringStream.Create(Json.AsJSON);
-       Response := Client.Post(FBaseUrl + '/cte/enviar');
+       Response := Client.Post(FBaseUrl + '/cte/cte');
        // Expecting 200 or 400 (validation error), but valid JSON
        if Client.ResponseStatusCode >= 400 then
          CheckResponse(Response, Client.ResponseStatusCode, Client.ResponseStatusCode)       
@@ -350,7 +350,7 @@ begin
       Json.Add('xml', XmlBase64);
       Client.RequestBody := TStringStream.Create(Json.AsJSON);
       try
-        Response := Client.Post(FBaseUrl + '/cte/enviar');
+        Response := Client.Post(FBaseUrl + '/cte/cte');
       except
         on E: EHTTPClient do
         begin

--- a/tests/unit/TestMDFe.pas
+++ b/tests/unit/TestMDFe.pas
@@ -66,7 +66,7 @@ begin
        Json.Add('config', CreateConfigJSON);
        // Add 'mdfe' object if required for stricter validation, but 400 with message is also a valid response from server for partial data
        Client.RequestBody := TStringStream.Create(Json.AsJSON);
-       Response := Client.Post(FBaseUrl + '/mdfe/enviar');
+       Response := Client.Post(FBaseUrl + '/mdfe/mdfe');
        if Client.ResponseStatusCode >= 400 then
          CheckResponse(Response, Client.ResponseStatusCode, Client.ResponseStatusCode)       
        else


### PR DESCRIPTION
Refactored several endpoints and fixed inconsistencies in the OpenAPI spec:
1. Updated CT-e endpoints to properly reflect `/cte/dacte` and `/cte/cte` instead of incorrect `/cte/danfe` and `/cte/nfe`.
2. Updated MDF-e endpoints to use `/mdfe/mdfe` consistently with other endpoints (matching its GET `/modelo/mdfe/mdfe` model representation).
3. Fixed `route.acbr.mdfe.pas` to use constants from `resource.strings.routes.pas` rather than hardcoded path strings.
4. Regenerated `swagger.yaml` to match these updates accurately.

---
*PR created automatically by Jules for task [15662431944616611632](https://jules.google.com/task/15662431944616611632) started by @macgayverarmini*