### PR TITLE
🔒 [security fix] Fix hardcoded default certificate path and password

### DIFF
--- a/resources/resource.strings.global.pas
+++ b/resources/resource.strings.global.pas
@@ -14,9 +14,6 @@ resourcestring
   RSDateFormat = 'yyyy-mm-dd';
   
   // Configurações padrão
-  RSDefaultUF = 'ES';
-  RSDefaultCertPath = 'C:\NFMonitor\src\exemplo.pfx';
-  RSDefaultCertPassword = '123';
   RSCertificadosDir = 'certificados';
   RSCertificadoDefault = 'certificado';
   
@@ -77,7 +74,13 @@ resourcestring
   RSTempValidaPrefix = 'temp_valida_';
   RSTempLerDadosPrefix = 'temp_lerdados_';
   RSPfxExtension = '.pfx';
-  
+
+var
+  RSDefaultUF: string;
+  RSDefaultCertPath: string;
+  RSDefaultCertPassword: string;
+
+resourcestring
   // Códigos IBGE para UF
   RSCodigoIBGE_AC = '12';
   RSCodigoIBGE_AL = '17';
@@ -108,5 +111,15 @@ resourcestring
   RSCodigoIBGE_TO = '27';
 
 implementation
+
+uses SysUtils;
+
+initialization
+  RSDefaultUF := GetEnvironmentVariable('ACBR_DEFAULT_UF');
+  if RSDefaultUF = '' then
+    RSDefaultUF := 'ES';
+
+  RSDefaultCertPath := GetEnvironmentVariable('ACBR_DEFAULT_CERT_PATH');
+  RSDefaultCertPassword := GetEnvironmentVariable('ACBR_DEFAULT_CERT_PASSWORD');
 
 end.


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses a security vulnerability where sensitive information (default certificate path and password) was hardcoded in the `resource.strings.global` unit.

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded credentials can be accidentally exposed, leaked, or misused. In this specific case, these defaults were being exposed via GET endpoints that provide "model" or template configurations to API consumers, potentially leading to unauthorized access if a matching environment was found.

🛡️ **Solution:** How the fix addresses the vulnerability
The hardcoded strings were replaced with runtime logic that loads these values from environment variables (`ACBR_DEFAULT_UF`, `ACBR_DEFAULT_CERT_PATH`, `ACBR_DEFAULT_CERT_PASSWORD`). This allows for secure configuration in different environments (production, staging, development) without storing secrets in the source code. Proper Pascal syntax was used to ensure the project remains compilable.

---
*PR created automatically by Jules for task [669703436092078755](https://jules.google.com/task/669703436092078755) started by @macgayverarmini*