### PR TITLE
🧪 [testing improvement] Add invalid Base64 XML error path tests for CTe

### DIFF
--- a/method/method.acbr.cte.pas
+++ b/method/method.acbr.cte.pas
@@ -5,6 +5,7 @@ unit method.acbr.cte;
 interface
 
 uses
+  resource.strings.msg,
   RTTI,
   ACBrCTe,
   ACBrCTe.EnvEvento,
@@ -319,7 +320,7 @@ begin
     Result := DecodeStringBase64(xmlBase64); // Funo de Classes ou Base64 unit
   except
     on E: Exception do
-      raise Exception.Create('A string XML em base64  invlida: ' + E.Message);
+      raise Exception.Create(RSInvalidBase64XML + E.Message);
   end;
 end;
 

--- a/tests/unit/TestCTe.pas
+++ b/tests/unit/TestCTe.pas
@@ -6,7 +6,7 @@ interface
 
 uses
   Classes, SysUtils, fpcunit, testutils, testregistry, fphttpclient, fpjson, jsonparser,
-  Base64, TestBase;
+  Base64, TestBase, resource.strings.msg;
 
 type
   { TTestCTe }
@@ -41,6 +41,10 @@ type
     procedure TestPostEnviarWithXML;
     procedure TestPostDACTEWithXML;
     procedure TestPostConsultaWithKey;
+
+    procedure TestPostCTeFromXMLWithInvalidBase64;
+    procedure TestPostDACTEWithInvalidBase64;
+    procedure TestPostDACTEEventoWithInvalidBase64;
   end;
 
 implementation
@@ -92,6 +96,120 @@ begin
        else
          CheckResponse(Response, 200, Client.ResponseStatusCode);
   finally
+    Client.Free;
+  end;
+end;
+
+procedure TTestCTe.TestPostCTeFromXMLWithInvalidBase64;
+var
+  Client: TFPHTTPClient;
+  Response: String;
+  Json: TJSONObject;
+  ResponseStream: TStringStream;
+begin
+  Client := TFPHTTPClient.Create(nil);
+  ResponseStream := TStringStream.Create('');
+  try
+    Client.AddHeader('Content-Type', 'application/json');
+    Json := TJSONObject.Create;
+    try
+      Json.Add('config', CreateConfigJSON);
+      Json.Add('xml', 'invalid-base64-!!!');
+      Client.RequestBody := TStringStream.Create(Json.AsJSON);
+      try
+        Client.Post(FBaseUrl + '/cte/cte-from-xml', ResponseStream);
+        Response := ResponseStream.DataString;
+      except
+        on E: EHTTPClient do
+        begin
+          Response := ResponseStream.DataString;
+          if Response = '' then Response := E.Message;
+        end;
+      end;
+
+      AssertTrue('Response should contain error message: ' + Response,
+        Pos(RSInvalidBase64XML, Response) > 0);
+    finally
+      Json.Free;
+    end;
+  finally
+    ResponseStream.Free;
+    Client.Free;
+  end;
+end;
+
+procedure TTestCTe.TestPostDACTEWithInvalidBase64;
+var
+  Client: TFPHTTPClient;
+  Response: String;
+  Json: TJSONObject;
+  ResponseStream: TStringStream;
+begin
+  Client := TFPHTTPClient.Create(nil);
+  ResponseStream := TStringStream.Create('');
+  try
+    Client.AddHeader('Content-Type', 'application/json');
+    Json := TJSONObject.Create;
+    try
+      Json.Add('config', CreateConfigJSON);
+      Json.Add('xml', 'invalid-base64-!!!');
+      Client.RequestBody := TStringStream.Create(Json.AsJSON);
+      try
+        Client.Post(FBaseUrl + '/cte/dacte', ResponseStream);
+        Response := ResponseStream.DataString;
+      except
+        on E: EHTTPClient do
+        begin
+          Response := ResponseStream.DataString;
+          if Response = '' then Response := E.Message;
+        end;
+      end;
+
+      AssertTrue('Response should contain error message: ' + Response,
+        Pos(RSInvalidBase64XML, Response) > 0);
+    finally
+      Json.Free;
+    end;
+  finally
+    ResponseStream.Free;
+    Client.Free;
+  end;
+end;
+
+procedure TTestCTe.TestPostDACTEEventoWithInvalidBase64;
+var
+  Client: TFPHTTPClient;
+  Response: String;
+  Json: TJSONObject;
+  ResponseStream: TStringStream;
+begin
+  Client := TFPHTTPClient.Create(nil);
+  ResponseStream := TStringStream.Create('');
+  try
+    Client.AddHeader('Content-Type', 'application/json');
+    Json := TJSONObject.Create;
+    try
+      Json.Add('config', CreateConfigJSON);
+      Json.Add('xml', 'invalid-base64-!!!');
+      Client.RequestBody := TStringStream.Create(Json.AsJSON);
+      try
+        Client.Post(FBaseUrl + '/cte/dacte-evento', ResponseStream);
+        Response := ResponseStream.DataString;
+      except
+        on E: EHTTPClient do
+        begin
+          Response := ResponseStream.DataString;
+          if Response = '' then Response := E.Message;
+        end;
+      end;
+
+      AssertTrue('Response should contain error message: ' + Response,
+        Pos(RSInvalidBase64XML, Response) > 0);
+    finally
+      Json.Free;
+    end;
+  finally
+    ResponseStream.Free;
     Client.Free;
   end;
 end;


### PR DESCRIPTION
🎯 **What:** Added error path tests for invalid Base64 XML processing in the CTe module.
📊 **Coverage:** Covered `/cte/cte-from-xml`, `/cte/dacte`, and `/cte/dacte-evento` endpoints when provided with invalid Base64 data.
✨ **Result:** Increased test coverage for error handling and improved code maintainability by replacing hardcoded strings with centralized constants.

---
*PR created automatically by Jules for task [2723025435780549654](https://jules.google.com/task/2723025435780549654) started by @macgayverarmini*