### PR TITLE
🧹 Standardize ACBr JSON conversion and error handling

### DIFF
--- a/method/method.acbr.cte.pas
+++ b/method/method.acbr.cte.pas
@@ -30,7 +30,8 @@ uses
   Classes, SysUtils,
   streamtools,
   ACBrCTeDACTeRL, // Para a instncia fdacte
-  ACBrUtil;       // Para GetTempFileName e possivelmente FileToStringBase64
+  ACBrUtil,       // Para GetTempFileName e possivelmente FileToStringBase64
+  resource.strings.global;
 
 type
 
@@ -263,7 +264,7 @@ end;
 function TACBRModelosJSONCTe.ModelDistribuicao: string;
 begin
   //  Evento := facbr.WebServices.DistribuicaoDFe.new;
-  Result := TJSONTools.ObjToJsonString(facbr.WebServices.DistribuicaoDFe);
+  Result := TJSONTools.SafeObjToJsonString(facbr.WebServices.DistribuicaoDFe);
   //  facbr.EventoNFe.Evento.Clear;
 end;
 
@@ -345,7 +346,6 @@ var
   Lote: integer;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   try
     ConhecimentoCTe := facbr.Conhecimentos.Add.CTe;
@@ -355,8 +355,7 @@ begin
   except
     on E: Exception do
     begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro na leitura do objeto JSON para CTe: ' + E.Message);
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na leitura do objeto JSON para CTe: ' + E.Message);
       if Assigned(facbr.Conhecimentos) then facbr.Conhecimentos.Clear;
       Exit;
     end;
@@ -364,11 +363,10 @@ begin
 
   try
     facbr.WebServices.Envia(Lote, True); // True para Assinar
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.Retorno, 'Erro ao enviar CTe');
   finally
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Retorno));
+    if Assigned(facbr.Conhecimentos) then facbr.Conhecimentos.Clear;
   end;
-
-  if Assigned(facbr.Conhecimentos) then facbr.Conhecimentos.Clear;
 end;
 
 function TACBRBridgeCTe.Evento(const jEventos: TJSONArray): string;
@@ -461,16 +459,12 @@ end;
 function TACBRBridgeCTe.StatusServico(const jStatus: TJSONObject): TJSONObject;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
   try
     facbr.WebServices.StatusServico.Executar;
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.StatusServico));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.StatusServico, 'Erro ao consultar status');
   except
     on E: Exception do
-    begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro ao consultar status: ' + E.Message);
-    end;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao consultar status: ' + E.Message);
   end;
 end;
 
@@ -479,44 +473,33 @@ var
   Chave: TJSONData;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   if jConsulta.Find('CTeChave', Chave) then
   begin
     try
       facbr.WebServices.Consulta.CTeChave := Chave.AsString;
       facbr.WebServices.Consulta.Executar;
-      Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Consulta));
+      Result := TJSONTools.SafeObjToJson(facbr.WebServices.Consulta, 'Erro na consulta');
     except
       on E: Exception do
-      begin
-        Result.Add('status', 'erro');
-        Result.Add('message', 'Erro na consulta: ' + E.Message);
-      end;
+        Result := TJSONTools.SafeObjToJson(nil, 'Erro na consulta: ' + E.Message);
     end;
   end
   else
-  begin
-    Result.Add('status', 'erro');
-    Result.Add('message', 'Chave nao informada para consulta.');
-  end;
+    Result := TJSONTools.SafeObjToJson(nil, 'Chave nao informada para consulta.');
 end;
 
 function TACBRBridgeCTe.Inutilizacao(const jInutilizacao: TJSONObject): TJSONObject;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
   
   try
     TJSONTools.JsonToObj(jInutilizacao, facbr.WebServices.Inutilizacao);
     facbr.WebServices.Inutilizacao.Executar;
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Inutilizacao));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.Inutilizacao, 'Erro na inutilizacao');
   except
     on E: Exception do
-    begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro na inutilizacao: ' + E.Message);
-    end;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na inutilizacao: ' + E.Message);
   end;
 end;
 
@@ -553,13 +536,10 @@ begin
 
   try
     facbr.EnviarEvento(idLote);
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.EnvEvento.EventoRetorno.retEvento));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.EnvEvento.EventoRetorno.retEvento, 'Erro ao enviar evento de cancelamento');
   except
     on E: Exception do
-    begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro ao enviar evento de cancelamento: ' + E.Message);
-    end;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao enviar evento de cancelamento: ' + E.Message);
   end;
 end;
 
@@ -568,32 +548,28 @@ var
   xmlBase64: string;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
   try
     xmlBase64 := ReadXMLFromJSON(jXML);
     facbr.Conhecimentos.LoadFromString(xmlBase64);
     if facbr.Conhecimentos.Count > 0 then
     begin
-      Result := TJSONObject(TJSONTools.ObjToJson(facbr.Conhecimentos.Items[0].CTe));
-      // Limpeza opcional de campos internos
-      Result.Delete('XML');
-      Result.Delete('XMLOriginal');
-      Result.Delete('NomeArq');
-      Result.Delete('Protocolo');
-      Result.Delete('DigVal');
-      Result.Delete('infCTeSupl');
+      Result := TJSONTools.SafeObjToJson(facbr.Conhecimentos.Items[0].CTe, 'Erro na conversao XML para JSON');
+      if Result.Find(RSStatusField) = nil then
+      begin
+        // Limpeza opcional de campos internos
+        Result.Delete('XML');
+        Result.Delete('XMLOriginal');
+        Result.Delete('NomeArq');
+        Result.Delete('Protocolo');
+        Result.Delete('DigVal');
+        Result.Delete('infCTeSupl');
+      end;
     end
     else
-    begin
-       Result.Add('status', 'erro');
-       Result.Add('message', 'Nenhum CTe carregado do XML.');
-    end;
+       Result := TJSONTools.SafeObjToJson(nil, 'Nenhum CTe carregado do XML.');
   except
     on E: Exception do
-    begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro na conversao XML para JSON: ' + E.Message);
-    end;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na conversao XML para JSON: ' + E.Message);
   end;
   facbr.Conhecimentos.Clear;
 end;
@@ -604,7 +580,6 @@ var
   xmlString: string;
 begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   try
     ConhecimentoCTe := facbr.Conhecimentos.Add.CTe;
@@ -612,8 +587,7 @@ begin
   except
     on E: Exception do
     begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro na leitura do objeto JSON para CTe: ' + E.Message);
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na leitura do objeto JSON para CTe: ' + E.Message);
       if Assigned(facbr.Conhecimentos) then facbr.Conhecimentos.Clear;
       Exit;
     end;
@@ -625,13 +599,11 @@ begin
     if xmlString = '' then
       xmlString := facbr.Conhecimentos.Items[0].XML;
 
+    Result := TJSONObject.Create;
     Result.Add('xml', EncodeStringBase64(xmlString));
   except
     on E: Exception do
-    begin
-      Result.Add('status', 'erro');
-      Result.Add('message', 'Erro ao gerar XML do CTe: ' + E.Message);
-    end;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao gerar XML do CTe: ' + E.Message);
   end;
 
   if Assigned(facbr.Conhecimentos) then facbr.Conhecimentos.Clear;
@@ -751,15 +723,17 @@ begin
       facbr.Conhecimentos.Items[0].Assinar;
       facbr.Conhecimentos.Items[0].Validar;
 
-      Result.Add('status', 'sucesso');
-      Result.Add('message', 'XML Valido e Assinado');
+      Result := TJSONObject.Create;
+      Result.Add(RSStatusField, 'sucesso');
+      Result.Add(RSMessageField, 'XML Valido e Assinado');
       // Retorna o XML assinado caso o cliente queira salvar
       Result.Add('xml_assinado', EncodeStringBase64(facbr.Conhecimentos.Items[0].XML));
     except
       on E: Exception do
       begin
-        Result.Add('status', 'erro_validacao');
-        Result.Add('message', E.Message);
+        Result := TJSONTools.SafeObjToJson(nil, E.Message);
+        Result.Delete(RSStatusField);
+        Result.Add(RSStatusField, 'erro_validacao');
         // O ACBr costuma popular a lista de erros de validação
         if facbr.Conhecimentos.Items[0].ErroValidacao <> '' then
            Result.Add('detalhes', facbr.Conhecimentos.Items[0].ErroValidacao);

--- a/method/method.acbr.mdfe.pas
+++ b/method/method.acbr.mdfe.pas
@@ -24,7 +24,8 @@ uses
   Base64, jsonparser,
   ACBrDFeConfiguracoes,
   ACBrMDFeConfiguracoes,
-  Classes, SysUtils;
+  Classes, SysUtils,
+  resource.strings.global;
 
 type
 
@@ -238,7 +239,7 @@ end;
 
 function TACBRModelosJSONMDFe.ModelDistribuicao: string;
 begin
-  Result := TJSONTools.ObjToJsonString(facbr.WebServices.DistribuicaoDFe);
+  Result := TJSONTools.SafeObjToJsonString(facbr.WebServices.DistribuicaoDFe);
 end;
 
 { TACBRBridgeMDFe }

--- a/method/method.acbr.nfe.pas
+++ b/method/method.acbr.nfe.pas
@@ -191,7 +191,7 @@ End;
 Function TACBRModelosJSON.ModelDistribuicao: string;
 Begin
   //  Evento := facbr.WebServices.DistribuicaoDFe.new;
-  Result := TJSONTools.ObjToJsonString(facbr.WebServices.DistribuicaoDFe);
+  Result := TJSONTools.SafeObjToJsonString(facbr.WebServices.DistribuicaoDFe);
   //  facbr.EventoNFe.Evento.Clear;
 End;
 
@@ -256,7 +256,6 @@ Var
 Begin
   CarregaConfig;
 
-  Result := TJSONObject.Create;
   //Gera objeto TNotaFiscal da unit ACBrNFeNotasFiscais
   Nota := facbr.NotasFiscais.Add;
   // Inicia o número do lote do envio da NFe
@@ -267,9 +266,7 @@ Begin
   Except
     on E: Exception Do
           Begin
-            Result.Add(RSStatusField, RSStatusErro);
-            Result.Add(RSMessageField, RSErrorReadingJSON + E.Message
-            );
+            Result := TJSONTools.SafeObjToJson(nil, RSErrorReadingJSON + E.Message);
             Exit;
           End;
 End;
@@ -277,11 +274,10 @@ End;
 Try
   // Pede a ACBR para transmitir os dados
   facbr.WebServices.Envia(Lote, True, False);
+  Result := TJSONTools.SafeObjToJson(facbr.WebServices.Retorno, 'Erro ao enviar NFe');
 Finally
-  Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Retorno));
+  facbr.NotasFiscais.Clear;
 End;
-
-facbr.NotasFiscais.Clear;
 End;
 
 
@@ -537,16 +533,12 @@ End;
 Function TACBRBridgeNFe.StatusServico(Const jStatus: TJSONObject): TJSONObject;
 Begin
   CarregaConfig;
-  Result := TJSONObject.Create;
   Try
     facbr.WebServices.StatusServico.Executar;
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.StatusServico));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.StatusServico, 'Erro ao consultar status');
   Except
     on E: Exception Do
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Erro ao consultar status: ' + E.Message);
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao consultar status: ' + E.Message);
   End;
 End;
 
@@ -555,44 +547,33 @@ Var
   Chave: TJSONData;
 Begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   If jConsulta.Find('NFe_Chave', Chave) Then
   Begin
     Try
       facbr.WebServices.Consulta.NFeChave := Chave.AsString;
       facbr.WebServices.Consulta.Executar;
-      Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Consulta));
+      Result := TJSONTools.SafeObjToJson(facbr.WebServices.Consulta, 'Erro na consulta');
     Except
       on E: Exception Do
-      Begin
-        Result.Add(RSStatusField, RSStatusErro);
-        Result.Add(RSMessageField, 'Erro na consulta: ' + E.Message);
-      End;
+        Result := TJSONTools.SafeObjToJson(nil, 'Erro na consulta: ' + E.Message);
     End;
   End
   Else
-  Begin
-    Result.Add(RSStatusField, RSStatusErro);
-    Result.Add(RSMessageField, 'Chave nao informada para consulta.');
-  End;
+    Result := TJSONTools.SafeObjToJson(nil, 'Chave nao informada para consulta.');
 End;
 
 Function TACBRBridgeNFe.Inutilizacao(Const jInutilizacao: TJSONObject): TJSONObject;
 Begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   Try
     TJSONTools.JsonToObj(jInutilizacao, facbr.WebServices.Inutilizacao);
     facbr.WebServices.Inutilizacao.Executar;
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.Inutilizacao));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.Inutilizacao, 'Erro na inutilizacao');
   Except
     on E: Exception Do
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Erro na inutilizacao: ' + E.Message);
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na inutilizacao: ' + E.Message);
   End;
 End;
 
@@ -627,13 +608,10 @@ Begin
 
   Try
     facbr.EnviarEvento(idLote);
-    Result := TJSONObject(TJSONTools.ObjToJson(facbr.WebServices.EnvEvento.EventoRetorno.retEvento));
+    Result := TJSONTools.SafeObjToJson(facbr.WebServices.EnvEvento.EventoRetorno.retEvento, 'Erro ao enviar evento de cancelamento');
   Except
     on E: Exception Do
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Erro ao enviar evento de cancelamento: ' + E.Message);
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao enviar evento de cancelamento: ' + E.Message);
   End;
 End;
 
@@ -642,32 +620,28 @@ Var
   xmlBase64: string;
 Begin
   CarregaConfig;
-  Result := TJSONObject.Create;
   Try
     xmlBase64 := ReadXMLFromJSON(jXML);
     facbr.NotasFiscais.LoadFromString(xmlBase64);
     If facbr.NotasFiscais.Count > 0 Then
     Begin
-      Result := TJSONObject(TJSONTools.ObjToJson(facbr.NotasFiscais.Items[0].NFe));
-      Result.Delete(RSXMLField);
-      Result.Delete(RSXMLOriginalField);
-      Result.Delete(RSNomeArqField);
-      Result.Delete(RSErroValidacaoCompletoField);
-      Result.Delete(RSErroValidacaoField);
-      Result.Delete(RSErroRegrasdeNegociosField);
-      Result.Delete(RSAlertasField);
+      Result := TJSONTools.SafeObjToJson(facbr.NotasFiscais.Items[0].NFe, 'Erro na conversao XML para JSON');
+      if Result.Find(RSStatusField) = nil then
+      begin
+        Result.Delete(RSXMLField);
+        Result.Delete(RSXMLOriginalField);
+        Result.Delete(RSNomeArqField);
+        Result.Delete(RSErroValidacaoCompletoField);
+        Result.Delete(RSErroValidacaoField);
+        Result.Delete(RSErroRegrasdeNegociosField);
+        Result.Delete(RSAlertasField);
+      end;
     End
     Else
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Nenhuma NF-e carregada do XML.');
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Nenhuma NF-e carregada do XML.');
   Except
     on E: Exception Do
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Erro na conversao XML para JSON: ' + E.Message);
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro na conversao XML para JSON: ' + E.Message);
   End;
   facbr.NotasFiscais.Clear;
 End;
@@ -678,7 +652,6 @@ Var
   xmlString: string;
 Begin
   CarregaConfig;
-  Result := TJSONObject.Create;
 
   Try
     Nota := facbr.NotasFiscais.Add;
@@ -686,8 +659,7 @@ Begin
   Except
     on E: Exception Do
     Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, RSErrorReadingJSON + E.Message);
+      Result := TJSONTools.SafeObjToJson(nil, RSErrorReadingJSON + E.Message);
       facbr.NotasFiscais.Clear;
       Exit;
     End;
@@ -699,13 +671,11 @@ Begin
     If xmlString = '' Then
       xmlString := facbr.NotasFiscais.Items[0].XML;
 
+    Result := TJSONObject.Create;
     Result.Add('xml', EncodeStringBase64(xmlString));
   Except
     on E: Exception Do
-    Begin
-      Result.Add(RSStatusField, RSStatusErro);
-      Result.Add(RSMessageField, 'Erro ao gerar XML da NF-e: ' + E.Message);
-    End;
+      Result := TJSONTools.SafeObjToJson(nil, 'Erro ao gerar XML da NF-e: ' + E.Message);
   End;
 
   facbr.NotasFiscais.Clear;
@@ -737,14 +707,16 @@ Begin
       facbr.NotasFiscais.Items[0].Assinar;
       facbr.NotasFiscais.Items[0].Validar;
 
+      Result := TJSONObject.Create;
       Result.Add(RSStatusField, 'sucesso');
       Result.Add(RSMessageField, 'XML Valido e Assinado');
       Result.Add('xml_assinado', EncodeStringBase64(facbr.NotasFiscais.Items[0].XML));
     Except
       on E: Exception Do
       Begin
+        Result := TJSONTools.SafeObjToJson(nil, E.Message);
+        Result.Delete(RSStatusField);
         Result.Add(RSStatusField, 'erro_validacao');
-        Result.Add(RSMessageField, E.Message);
         If facbr.NotasFiscais.Items[0].ErroValidacao <> '' Then
           Result.Add('detalhes', facbr.NotasFiscais.Items[0].ErroValidacao);
       End;

--- a/tools/jsonconvert.pas
+++ b/tools/jsonconvert.pas
@@ -8,7 +8,8 @@ uses
   fpjson,
   Horse.HandleException, jsonparser,
   pcnConversaoNFe, pcnConversao,
-  Classes, SysUtils, fpjsonrtti;
+  Classes, SysUtils, fpjsonrtti,
+  resource.strings.global;
 
 type
 
@@ -19,6 +20,9 @@ type
     class function ObjToJsonString(const Obj: TObject): string;
     class function ObjToJson(const Obj: TObject): TJSONObject;
 
+    class function SafeObjToJson(const Obj: TObject; const ErrorMsg: string = ''): TJSONObject;
+    class function SafeObjToJsonString(const Obj: TObject; const ErrorMsg: string = ''): string;
+
     class procedure JsonStringToObj(const JsonString: string; const Obj: TObject);
     class procedure JsonToObj(const Json: TJSONObject; const Obj: TObject);
   end;
@@ -26,6 +30,45 @@ type
 implementation
 
 { TJSONTools }
+
+class function TJSONTools.SafeObjToJson(const Obj: TObject; const ErrorMsg: string): TJSONObject;
+begin
+  try
+    if Assigned(Obj) then
+      Result := ObjToJson(Obj)
+    else
+    begin
+      Result := TJSONObject.Create;
+      Result.Add(RSStatusField, RSStatusErro);
+      if ErrorMsg <> '' then
+        Result.Add(RSMessageField, ErrorMsg)
+      else
+        Result.Add(RSMessageField, 'Objeto não instanciado');
+    end;
+  except
+    on E: Exception do
+    begin
+      Result := TJSONObject.Create;
+      Result.Add(RSStatusField, RSStatusErro);
+      if ErrorMsg <> '' then
+        Result.Add(RSMessageField, ErrorMsg + ': ' + E.Message)
+      else
+        Result.Add(RSMessageField, E.Message);
+    end;
+  end;
+end;
+
+class function TJSONTools.SafeObjToJsonString(const Obj: TObject; const ErrorMsg: string): string;
+var
+  LJson: TJSONObject;
+begin
+  LJson := SafeObjToJson(Obj, ErrorMsg);
+  try
+    Result := LJson.AsJSON;
+  finally
+    LJson.Free;
+  end;
+end;
 
 class function TJSONTools.ObjToJsonString(const Obj: TObject): string;
 var


### PR DESCRIPTION
Standardized the conversion of ACBr objects to JSON by introducing utility methods in `TJSONTools` and refactoring bridge methods in `method/` to use them. This reduces code repetition, ensures consistent error handling, and fixes minor memory leaks in error paths.

---
*PR created automatically by Jules for task [7892124599582241386](https://jules.google.com/task/7892124599582241386) started by @macgayverarmini*