### PR TITLE
⚡ Bolt: [performance improvement] Optimize TRttiContext allocation in JSON conversion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - Optimize TRttiContext allocation in JSON conversion
+**Learning:** In FPC/Delphi, `TRttiContext.Create` is relatively expensive because it sets up the context for reflection. Creating and destroying it repeatedly inside recursive serialization and deserialization functions (like converting JSON to nested objects) creates significant overhead.
+**Action:** Always create `TRttiContext` once in the public entry points of serialization/deserialization utilities and pass it as a `const` parameter down to internal recursive methods.

--- a/tools/jsonconvert.pas
+++ b/tools/jsonconvert.pas
@@ -17,9 +17,10 @@ type
 
   TJSONTools = class
   private
-    class procedure PopulateObjectList(AListObj: TObject; AArray: TJSONArray);
-    class function InternalObjToJson(const Obj: TObject; Visited: TList): TJSONData;
-    class function ValueToJson(const Value: TValue; Visited: TList): TJSONData;
+    class procedure PopulateObjectList(AListObj: TObject; AArray: TJSONArray; const Ctx: TRttiContext);
+    class function InternalObjToJson(const Obj: TObject; Visited: TList; const Ctx: TRttiContext): TJSONData;
+    class function ValueToJson(const Value: TValue; Visited: TList; const Ctx: TRttiContext): TJSONData;
+    class procedure InternalJsonToObj(const Json: TJSONObject; const Obj: TObject; const Ctx: TRttiContext);
   public
     class function ObjToJsonString(const Obj: TObject): string;
     class function ObjToJson(const Obj: TObject): TJSONObject;
@@ -41,11 +42,10 @@ type
 
 { TJSONTools }
 
-class procedure TJSONTools.PopulateObjectList(AListObj: TObject; AArray: TJSONArray);
+class procedure TJSONTools.PopulateObjectList(AListObj: TObject; AArray: TJSONArray; const Ctx: TRttiContext);
 var
   I: Integer;
   LNewItem: TObject;
-  Ctx: TRttiContext;
   RttiType: TRttiType;
   RttiMethod: TRttiMethod;
 begin
@@ -68,38 +68,33 @@ begin
       begin
         LNewItem := TCollection(AListObj).Add;
         if Assigned(LNewItem) then
-          JsonToObj(TJSONObject(AArray.Items[I]), LNewItem);
+          InternalJsonToObj(TJSONObject(AArray.Items[I]), LNewItem, Ctx);
       end;
     end;
     Exit;
   end;
 
-  Ctx := TRttiContext.Create(False);
-  try
-    RttiType := Ctx.GetType(AListObj.ClassType);
-    if not Assigned(RttiType) then Exit;
+  RttiType := Ctx.GetType(AListObj.ClassType);
+  if not Assigned(RttiType) then Exit;
 
-    RttiMethod := RttiType.GetMethod('New');
-    if not Assigned(RttiMethod) then
-      RttiMethod := RttiType.GetMethod('NEW');
-    
-    if not Assigned(RttiMethod) then
-      RttiMethod := RttiType.GetMethod('new');
+  RttiMethod := RttiType.GetMethod('New');
+  if not Assigned(RttiMethod) then
+    RttiMethod := RttiType.GetMethod('NEW');
 
-    if Assigned(RttiMethod) then
+  if not Assigned(RttiMethod) then
+    RttiMethod := RttiType.GetMethod('new');
+
+  if Assigned(RttiMethod) then
+  begin
+    for I := 0 to AArray.Count - 1 do
     begin
-      for I := 0 to AArray.Count - 1 do
+      if AArray.Items[I] is TJSONObject then
       begin
-        if AArray.Items[I] is TJSONObject then
-        begin
-          LNewItem := RttiMethod.Invoke(AListObj, []).AsObject;
-          if Assigned(LNewItem) then
-            JsonToObj(TJSONObject(AArray.Items[I]), LNewItem);
-        end;
+        LNewItem := RttiMethod.Invoke(AListObj, []).AsObject;
+        if Assigned(LNewItem) then
+          InternalJsonToObj(TJSONObject(AArray.Items[I]), LNewItem, Ctx);
       end;
     end;
-  finally
-    Ctx.Free;
   end;
 end;
 
@@ -159,7 +154,7 @@ begin
     Result := '{}';
 end;
 
-class function TJSONTools.ValueToJson(const Value: TValue; Visited: TList): TJSONData;
+class function TJSONTools.ValueToJson(const Value: TValue; Visited: TList; const Ctx: TRttiContext): TJSONData;
 var
   Obj: TObject;
   EnumName: string;
@@ -197,16 +192,15 @@ begin
     tkClass:
       begin
         Obj := Value.AsObject;
-        Result := InternalObjToJson(Obj, Visited);
+        Result := InternalObjToJson(Obj, Visited, Ctx);
       end;
   else
     Result := TJSONNull.Create;
   end;
 end;
 
-class function TJSONTools.InternalObjToJson(const Obj: TObject; Visited: TList): TJSONData;
+class function TJSONTools.InternalObjToJson(const Obj: TObject; Visited: TList; const Ctx: TRttiContext): TJSONData;
 var
-  Ctx: TRttiContext;
   RttiType: TRttiType;
   Props: TRttiPropertyArray;
   Prop: TRttiProperty;
@@ -237,7 +231,7 @@ begin
       ArrJson := TJSONArray.Create;
       for i := 0 to TCollection(Obj).Count - 1 do
       begin
-        ArrJson.Add(InternalObjToJson(TCollection(Obj).Items[i], Visited));
+        ArrJson.Add(InternalObjToJson(TCollection(Obj).Items[i], Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
@@ -247,7 +241,7 @@ begin
       ArrJson := TJSONArray.Create;
       for i := 0 to TObjectList(Obj).Count - 1 do
       begin
-        ArrJson.Add(InternalObjToJson(TObjectList(Obj).Items[i], Visited));
+        ArrJson.Add(InternalObjToJson(TObjectList(Obj).Items[i], Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
@@ -258,34 +252,29 @@ begin
       for i := 0 to TList(Obj).Count - 1 do
       begin
         ItemObj := TObject(TList(Obj).Items[i]);
-        ArrJson.Add(InternalObjToJson(ItemObj, Visited));
+        ArrJson.Add(InternalObjToJson(ItemObj, Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
 
     ObjJson := TJSONObject.Create;
     
-    Ctx := TRttiContext.Create(False);
-    try
-      RttiType := Ctx.GetType(Obj.ClassType);
-      if Assigned(RttiType) then
+    RttiType := Ctx.GetType(Obj.ClassType);
+    if Assigned(RttiType) then
+    begin
+      Props := RttiType.GetProperties;
+      for i := 0 to Length(Props) - 1 do
       begin
-        Props := RttiType.GetProperties;
-        for i := 0 to Length(Props) - 1 do
+        Prop := Props[i];
+        if Prop.IsReadable and (Prop.Visibility in [mvPublic, mvPublished]) then
         begin
-          Prop := Props[i];
-          if Prop.IsReadable and (Prop.Visibility in [mvPublic, mvPublished]) then
-          begin
-            try
-              Val := Prop.GetValue(Obj);
-              ObjJson.Add(Prop.Name, ValueToJson(Val, Visited));
-            except
-            end;
+          try
+            Val := Prop.GetValue(Obj);
+            ObjJson.Add(Prop.Name, ValueToJson(Val, Visited, Ctx));
+          except
           end;
         end;
       end;
-    finally
-      Ctx.Free;
     end;
 
     Result := ObjJson;
@@ -298,19 +287,25 @@ class function TJSONTools.ObjToJson(const Obj: TObject): TJSONObject;
 var
   Visited: TList;
   Data: TJSONData;
+  Ctx: TRttiContext;
 begin
   if Obj = nil then
     Exit(nil);
 
   Visited := TList.Create;
   try
-    Data := InternalObjToJson(Obj, Visited);
-    if Data is TJSONObject then
-      Result := TJSONObject(Data)
-    else
-    begin
-      Result := TJSONObject.Create; 
-      Data.Free;
+    Ctx := TRttiContext.Create(False);
+    try
+      Data := InternalObjToJson(Obj, Visited, Ctx);
+      if Data is TJSONObject then
+        Result := TJSONObject(Data)
+      else
+      begin
+        Result := TJSONObject.Create;
+        Data.Free;
+      end;
+    finally
+      Ctx.Free;
     end;
   finally
     Visited.Free;
@@ -336,6 +331,17 @@ end;
 class procedure TJSONTools.JsonToObj(const Json: TJSONObject; const Obj: TObject);
 var
   Ctx: TRttiContext;
+begin
+  Ctx := TRttiContext.Create(False);
+  try
+    InternalJsonToObj(Json, Obj, Ctx);
+  finally
+    Ctx.Free;
+  end;
+end;
+
+class procedure TJSONTools.InternalJsonToObj(const Json: TJSONObject; const Obj: TObject; const Ctx: TRttiContext);
+var
   RttiType: TRttiType;
   Prop: TRttiProperty;
   i: Integer;
@@ -348,84 +354,79 @@ var
 begin
   if (Json = nil) or (Obj = nil) then Exit;
 
-  Ctx := TRttiContext.Create(False);
-  try
-    RttiType := Ctx.GetType(Obj.ClassType);
-    if not Assigned(RttiType) then Exit;
+  RttiType := Ctx.GetType(Obj.ClassType);
+  if not Assigned(RttiType) then Exit;
 
-    for i := 0 to Json.Count - 1 do
+  for i := 0 to Json.Count - 1 do
+  begin
+    PropStr := Json.Names[i];
+    JsonVal := Json.Items[i];
+    if JsonVal.IsNull then Continue;
+
+    Prop := RttiType.GetProperty(PropStr);
+    if Assigned(Prop) then
     begin
-      PropStr := Json.Names[i];
-      JsonVal := Json.Items[i];
-      if JsonVal.IsNull then Continue;
-
-      Prop := RttiType.GetProperty(PropStr);
-      if Assigned(Prop) then
+      if Prop.PropertyType.TypeKind = tkClass then
       begin
-        if Prop.PropertyType.TypeKind = tkClass then
+        Val := Prop.GetValue(Obj);
+        ObjRef := Val.AsObject;
+        if Assigned(ObjRef) then
         begin
-          Val := Prop.GetValue(Obj);
-          ObjRef := Val.AsObject;
-          if Assigned(ObjRef) then
-          begin
-            if JsonVal is TJSONObject then
-              JsonToObj(TJSONObject(JsonVal), ObjRef)
-            else if JsonVal is TJSONArray then
-              PopulateObjectList(ObjRef, TJSONArray(JsonVal));
-          end;
-        end
-        else if Prop.IsWritable then
-        begin
-          try
-            case Prop.PropertyType.TypeKind of
-              tkInteger, tkInt64, tkQWord:
-                Prop.SetValue(Obj, TValue.From<Int64>(JsonVal.AsInt64));
-              tkFloat:
+          if JsonVal is TJSONObject then
+            InternalJsonToObj(TJSONObject(JsonVal), ObjRef, Ctx)
+          else if JsonVal is TJSONArray then
+            PopulateObjectList(ObjRef, TJSONArray(JsonVal), Ctx);
+        end;
+      end
+      else if Prop.IsWritable then
+      begin
+        try
+          case Prop.PropertyType.TypeKind of
+            tkInteger, tkInt64, tkQWord:
+              Prop.SetValue(Obj, TValue.From<Int64>(JsonVal.AsInt64));
+            tkFloat:
+              begin
+                if Prop.PropertyType.Handle = TypeInfo(TDateTime) then
                 begin
-                  if Prop.PropertyType.Handle = TypeInfo(TDateTime) then
+                  if JsonVal is TJSONString then
                   begin
-                    if JsonVal is TJSONString then
-                    begin
-                      if TryISO8601ToDate(JsonVal.AsString, LDate, False) then
-                        Prop.SetValue(Obj, TValue.From<Extended>(LDate))
-                      else
-                        Prop.SetValue(Obj, TValue.From<Extended>(StrToDateTimeDef(JsonVal.AsString, 0)));
-                    end
-                    else if JsonVal is TJSONNumber then
-                      Prop.SetValue(Obj, TValue.From<Extended>(JsonVal.AsFloat));
+                    if TryISO8601ToDate(JsonVal.AsString, LDate, False) then
+                      Prop.SetValue(Obj, TValue.From<Extended>(LDate))
+                    else
+                      Prop.SetValue(Obj, TValue.From<Extended>(StrToDateTimeDef(JsonVal.AsString, 0)));
                   end
-                  else
-                  begin
-                    if JsonVal is TJSONString then
-                      Prop.SetValue(Obj, TValue.From<Extended>(StrToFloatDef(JsonVal.AsString, 0)))
-                    else if JsonVal is TJSONNumber then
-                      Prop.SetValue(Obj, TValue.From<Extended>(JsonVal.AsFloat));
-                  end;
-                end;
-              tkString, tkUString, tkAString, tkWString, tkChar, tkWChar, tkUChar:
-                Prop.SetValue(Obj, TValue.From<string>(JsonVal.AsString));
-              tkEnumeration:
-                if Prop.PropertyType.Handle = TypeInfo(Boolean) then
-                  Prop.SetValue(Obj, TValue.From<Boolean>(JsonVal.AsBoolean))
+                  else if JsonVal is TJSONNumber then
+                    Prop.SetValue(Obj, TValue.From<Extended>(JsonVal.AsFloat));
+                end
                 else
                 begin
-                  EnumVal := GetEnumValue(Prop.PropertyType.Handle, JsonVal.AsString);
-                  if EnumVal >= 0 then
-                    Prop.SetValue(Obj, TValue.FromOrdinal(Prop.PropertyType.Handle, EnumVal));
+                  if JsonVal is TJSONString then
+                    Prop.SetValue(Obj, TValue.From<Extended>(StrToFloatDef(JsonVal.AsString, 0)))
+                  else if JsonVal is TJSONNumber then
+                    Prop.SetValue(Obj, TValue.From<Extended>(JsonVal.AsFloat));
                 end;
-              tkSet:
-                begin
-                  EnumVal := StringToSet(Prop.PropertyType.Handle, JsonVal.AsString);
+              end;
+            tkString, tkUString, tkAString, tkWString, tkChar, tkWChar, tkUChar:
+              Prop.SetValue(Obj, TValue.From<string>(JsonVal.AsString));
+            tkEnumeration:
+              if Prop.PropertyType.Handle = TypeInfo(Boolean) then
+                Prop.SetValue(Obj, TValue.From<Boolean>(JsonVal.AsBoolean))
+              else
+              begin
+                EnumVal := GetEnumValue(Prop.PropertyType.Handle, JsonVal.AsString);
+                if EnumVal >= 0 then
                   Prop.SetValue(Obj, TValue.FromOrdinal(Prop.PropertyType.Handle, EnumVal));
-                end;
-            end;
-          except
+              end;
+            tkSet:
+              begin
+                EnumVal := StringToSet(Prop.PropertyType.Handle, JsonVal.AsString);
+                Prop.SetValue(Obj, TValue.FromOrdinal(Prop.PropertyType.Handle, EnumVal));
+              end;
           end;
+        except
         end;
       end;
     end;
-  finally
-    Ctx.Free;
   end;
 end;
 


### PR DESCRIPTION
**💡 What**: 
Refactored the internal recursive methods of `TJSONTools` (`InternalObjToJson`, `JsonToObj`, `PopulateObjectList`, `ValueToJson`) to accept a `const Ctx: TRttiContext`. Extracted the instantiation (`TRttiContext.Create(False)`) to the public entry points.

**🎯 Why**: 
In Free Pascal and Delphi, `TRttiContext.Create` performs initializations and internal bookkeeping related to reflection. Creating and destroying this context inside a recursive serialization/deserialization loop (like when converting complex or nested objects to/from JSON) adds significant overhead and redundant allocations.

**📊 Impact**: 
Reduces reflection overhead substantially for large and deeply nested objects. Instead of O(N) context creations (where N is the number of nested objects/arrays), it's now O(1) context creation per top-level API call. 

**🔬 Measurement**: 
Verified via logic inspection. The recursive tree traversal logic remains strictly identical; only the `TRttiContext` scope was shifted outward to live across the entire traversal. Also documented the learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [11490682075988620393](https://jules.google.com/task/11490682075988620393) started by @macgayverarmini*