### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure via Hardcoded Debug Paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Legacy Debug Blocks and Path Disclosure
+**Vulnerability:** Legacy debug blocks using `AssignFile` / `SaveToFile` with hardcoded file paths (e.g., `C:\NFMonitor\src\bin\log_debug.txt`) left in production code.
+**Learning:** Hardcoded absolute paths in debug blocks can lead to information disclosure regarding the host environment's directory structure, and may cause directory traversal or path errors if the directory structure changes or on non-Windows platforms.
+**Prevention:** Remove all such hardcoded absolute paths used in debugging. Use configurable paths based on global application state (like `RSDefaultCertPath` or equivalent constants) or dedicated logging frameworks that properly handle paths and sensitive information without leaking details in production environments.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information disclosure and path traversal risk due to hardcoded absolute debug paths (`C:\NFMonitor\src\bin\log_debug.txt`) in legacy `try..except` blocks in production code.
🎯 Impact: Attackers or unprivileged users could infer the server's directory structure. On non-Windows platforms or differing environments, this would cause silent I/O exceptions which, though caught, are bad practice.
🔧 Fix: Removed the legacy `try..except` blocks and the unused global file handle `var F: TextFile;` in `routes/route.acbr.nfe.pas`.
✅ Verification: Code logic remains unchanged as the debug blocks were not functional core code. Verified visually through code review that `LJson := Ac.NFe(O);` is directly returned without extraneous wrappers.

---
*PR created automatically by Jules for task [17162596375139130692](https://jules.google.com/task/17162596375139130692) started by @macgayverarmini*