### PR TITLE
⚡ Bolt: Optimize Base64 stream conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Optimize Base64 Stream Conversions
+**Learning:** In Lazarus/FPC, passing the same inline function call multiple times as arguments to a procedure (e.g., `WriteBuffer(Func()[1], Length(Func()))`) causes the compiler to evaluate the function redundantly.
+**Action:** Store the result of expensive computations in a local variable before use. Also, avoid unnecessary string-to-bytes-to-string round-trips when interacting with functions that natively accept string inputs.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,39 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then
+    Exit('');
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  encodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  if Length(AString) = 0 then
+    Exit;
+  encodedStr := base64.EncodeStringBase64(AString);
+  if Length(encodedStr) > 0 then
+    Result.WriteBuffer(encodedStr[1], Length(encodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then
+    Exit('');
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +78,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:**
- Refactored `StringToBase64Stream` to store the encoded base64 result in a local variable rather than calling `base64.EncodeStringBase64` twice inline.
- Refactored `Base64StreamToString`, `StreamToBase64String`, and `StringToBase64Stream` to use native FreePascal strings directly as byte buffers (`ReadBuffer(str[1], Size)`) rather than allocating intermediary `TBytes` arrays and converting them via `TEncoding.UTF8`.
- Added critical empty-stream and empty-string boundary checks (`if Size = 0 then Exit`) to prevent out-of-bounds array access (`str[1]`) when streams or inputs are empty.

🎯 **Why:**
- Calling computationally expensive functions like base64 encoding twice just to retrieve its first element and its length causes the compiler to evaluate the function redundantly.
- Allocating intermediary arrays using `TEncoding.UTF8.GetBytes` and `GetString` creates unnecessary memory allocations and CPU overhead when dealing with binary or simple ASCII stream content.

📊 **Impact:**
- Significantly reduces memory allocation overhead and reduces the CPU cycles for `StringToBase64Stream` by ~50% by caching the encoding result. Eliminates the risk of `Range Check Errors` or `Access Violations` on empty inputs.

🔬 **Measurement:**
- Manual code review confirms that `base64.EncodeStringBase64` is now called exactly once per function execution, and intermediary `TBytes` structures have been completely removed.
- Review confirms bounds checks are in place before accessing `[1]`.

---
*PR created automatically by Jules for task [11847903235739150391](https://jules.google.com/task/11847903235739150391) started by @macgayverarmini*