### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix hardcoded debug log path vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Remove Hardcoded Debugging Path
+**Vulnerability:** Hardcoded absolute path `C:\NFMonitor\src\bin\log_debug.txt` used for legacy debug logging in `routes/route.acbr.nfe.pas`.
+**Learning:** Legacy debug logging blocks with hardcoded absolute file paths can leak sensitive internal directory structures and result in runtime errors/crashes across environments.
+**Prevention:** Use standardized logging mechanisms and configurable paths (e.g. `RSDefaultCertPath` or similar configuration). Always remove local debug blocks before committing.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Hardcoded absolute path `C:\NFMonitor\src\bin\log_debug.txt` was used for debug logging inside `try..except` blocks in `routes/route.acbr.nfe.pas`.
🎯 Impact: This can leak sensitive internal directory structures, cause permission denied exceptions, or lead to silent crashes in environments where the path does not exist.
🔧 Fix: Removed the legacy `AssignFile`/`WriteLn` try-except blocks completely, as they shouldn't be in production code, and removed the unused `var F: TextFile;` global variable. Added a `.jules/sentinel.md` journal entry.
✅ Verification: Code manually reviewed and unit tests run. The vulnerable legacy debug path is no longer present.

---
*PR created automatically by Jules for task [1396158807450738739](https://jules.google.com/task/1396158807450738739) started by @macgayverarmini*