### PR TITLE
⚡ Bolt: [performance improvement] Optimize streamtools string conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid TEncoding.UTF8 byte arrays for Stream strings
+**Learning:** `TEncoding.UTF8.GetBytes` and `TEncoding.UTF8.GetString` create unnecessary byte array allocations when doing Stream string operations in FPC/Lazarus. Strings can be cast directly.
+**Action:** Use native string indexing `str[1]` directly with `ReadBuffer` and `WriteBuffer` to avoid `TBytes` overhead.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,41 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if (AStream = nil) or (AStream.Size = 0) then Exit;
+
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  strBase64: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  if Length(AString) = 0 then Exit;
+
+  strBase64 := base64.EncodeStringBase64(AString);
+  if Length(strBase64) > 0 then
+    Result.WriteBuffer(strBase64[1], Length(strBase64));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if (AStream = nil) or (AStream.Size = 0) then Exit;
+
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +80,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:** Replaced inefficient `TEncoding.UTF8.GetBytes/GetString` overhead with zero-copy stream `ReadBuffer`/`WriteBuffer` string indexing in `tools/streamtools.pas`. Also stored `base64.EncodeStringBase64` result in a local variable to prevent executing the encoding twice in `StringToBase64Stream`. Added defensive empty stream checks.
🎯 **Why:** `TEncoding.UTF8.GetBytes` and `.GetString` create unnecessary byte array allocations when doing Stream string operations in FPC/Lazarus. In `StringToBase64Stream`, the `EncodeStringBase64` was previously executed twice: once to get the buffer index, and again to get the string length.
📊 **Impact:** Reduces CPU cycles and unnecessary `TBytes` buffer allocations significantly during every stream-to-base64 operation.
🔬 **Measurement:** Code Review. Local FPC benchmarks (not available in environment) would confirm reduced allocation overhead and faster encoding times.

---
*PR created automatically by Jules for task [18014401917385842090](https://jules.google.com/task/18014401917385842090) started by @macgayverarmini*