### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information disclosure in debug logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Information Disclosure via Hardcoded Legacy Debug Logs
+**Vulnerability:** Legacy debug statements (`AssignFile`, `SaveToFile`) using hardcoded absolute file paths like `C:\NFMonitor\src\bin\log_debug.txt` within web routes and method implementations.
+**Learning:** These paths can expose execution flow, sensitive timing data, and internal system structure when exceptions occur or if log files are globally readable on a Windows deployment, presenting an information disclosure vulnerability. They often get forgotten and committed during debugging.
+**Prevention:** Remove all such hardcoded file logging within production code. Use a centralized logging framework or configurable paths that map appropriately to container/runtime variables instead of literal C-drive directories.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Legacy debug statements (`AssignFile`) were writing log information to hardcoded absolute Windows paths (`C:\NFMonitor\src\bin\log_debug.txt`). Additionally, the file descriptor `var F: TextFile;` was declared globally, creating potential concurrency issues and DoS risks on concurrent requests.
🎯 **Impact:** Exposes internal directory structures, execution flow timing to local file system readers, and causes race conditions when handling multiple web requests.
🔧 **Fix:** Removed the hardcoded `AssignFile` logging blocks and the global `F` variable declaration from `routes/route.acbr.nfe.pas`.
✅ **Verification:** Verify by running code review on `routes/route.acbr.nfe.pas` and noting the absence of `C:\NFMonitor` absolute paths.

---
*PR created automatically by Jules for task [18307763204645197938](https://jules.google.com/task/18307763204645197938) started by @macgayverarmini*