### PR TITLE
⚡ Bolt: [performance improvement] Optimize stream and base64 string conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-07 - Avoid TEncoding Roundtrips and Redundant Function Evaluations
+**Learning:** In Free Pascal/Delphi, avoiding `TEncoding.UTF8.GetString` and `GetBytes` when interacting with streams significantly reduces memory allocation and O(N) operations by allowing reads/writes directly from string buffers (e.g., `ReadBuffer(str[1], AStream.Size)`). Additionally, inline procedure arguments like `WriteBuffer(Func()[1], Length(Func()))` result in redundant executions of the function `Func()`.
+**Action:** Always read directly into pre-allocated string buffers from streams and store results of expensive inline function calls in local variables when they are needed multiple times as procedure arguments.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,45 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then
+    Exit('');
+
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  // Read directly into string buffer, avoiding TBytes allocation and GetString
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
+
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  encodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // Encode directly from string, avoiding string-to-bytes-to-string roundtrips
+  encodedStr := base64.EncodeStringBase64(AString);
+  if Length(encodedStr) > 0 then
+    // Store in local variable to avoid evaluating EncodeStringBase64 multiple times
+    Result.WriteBuffer(encodedStr[1], Length(encodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  rawStr: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then
+    Exit('');
+
+  SetLength(rawStr, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  // Read directly into string buffer, avoiding TBytes allocation and GetString
+  AStream.ReadBuffer(rawStr[1], AStream.Size);
+
+  Result := base64.EncodeStringBase64(rawStr);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +84,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
### 💡 What:
Optimized `Base64StreamToString`, `StringToBase64Stream`, and `StreamToBase64String` in `tools/streamtools.pas` to perform direct buffer reads/writes and avoid unnecessary transformations.

### 🎯 Why:
The original implementation performed costly string-to-bytes-to-string roundtrips and instantiated intermediate `TBytes` buffers for operations that could be handled natively via strings. In `StringToBase64Stream`, `base64.EncodeStringBase64` was passed as both the value and length arguments to `WriteBuffer`, causing the expensive encoding function to be computed twice per string.

### 📊 Impact:
*   Significantly reduces memory allocations by eliminating intermediate `TBytes` buffers.
*   Halves the computation time for `StringToBase64Stream` by evaluating the base64 encoding only once.
*   Improves safety when reading binary payload arrays by skipping `TEncoding.UTF8` decoding on non-UTF8 binary data.

### 🔬 Measurement:
Verifiable via source code review. The optimized stream-to-string procedures process the exact same base64 structure without redundant encodings and `TBytes` overhead. Bounds checking has been explicitly included to prevent Range Check/Out of Bounds exceptions when payloads are empty.

---
*PR created automatically by Jules for task [12318415378888231876](https://jules.google.com/task/12318415378888231876) started by @macgayverarmini*