### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix concurrency vulnerability in route logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - DoS Vulnerability in Horse Routes via Global File Handlers
+**Vulnerability:** A global file descriptor (`var F: TextFile;`) was declared and used in a route implementation (`routes/route.acbr.nfe.pas`) to write debug logs to a hardcoded path.
+**Learning:** In a concurrent web framework like Horse, global variables shared across requests cause severe race conditions. Using a global file handle across multiple requests will cause file locking errors, thread contention, and can be easily exploited to cause a Denial of Service (DoS) by sending concurrent requests.
+**Prevention:** Never use global state (like file descriptors, temporary object instances, or hardcoded absolute file paths) within web route implementation files. Debugging should use proper logging mechanisms (e.g., Horse-Logger) configured per-instance.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A global file descriptor (`var F: TextFile;`) was declared in `routes/route.acbr.nfe.pas` and used within the `PostNFe` route to write debug logs to a hardcoded path.
🎯 Impact: Using global variables across requests in a concurrent web framework like Horse causes race conditions. Multiple concurrent requests trying to lock and write to the same file via the same global handler will cause runtime exceptions, file lock errors, and potentially crash the worker thread/process, leading to a Denial of Service (DoS).
🔧 Fix: Removed the global `F` variable and the associated temporary development debug logging blocks `AssignFile` from `PostNFe`.
✅ Verification: Manually verified the file content to ensure no remaining references to the global file descriptor `F` or hardcoded debugging file paths exist in the implementation section.

---
*PR created automatically by Jules for task [9479632888907257373](https://jules.google.com/task/9479632888907257373) started by @macgayverarmini*