### PR TITLE
🛡️ Sentinel: [HIGH] Fix concurrency issue and information disclosure in web routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-28 - Global File Handler Concurrency/DoS Vulnerability
+**Vulnerability:** A global file descriptor (`var F: TextFile;`) combined with legacy hardcoded debug logging (`AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt')`) within HTTP route handlers (e.g., `routes/route.acbr.nfe.pas`) created a race condition.
+**Learning:** In asynchronous/concurrent web frameworks like Horse, global shared resources within the `implementation` section can lead to concurrent access conflicts resulting in DoS, data corruption, and unauthorized file modification. Additionally, writing to hardcoded global paths exposes internal path information.
+**Prevention:** Remove global variables used within endpoint functions. Remove legacy debugging code from production handlers. Use proper contextual logging mechanisms without shared global resources to manage concurrent requests correctly.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A global file descriptor (`var F: TextFile;`) combined with legacy hardcoded debug logging (`AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt')`) within the `routes/route.acbr.nfe.pas` HTTP route handler.
🎯 **Impact:** In the asynchronous Horse web framework, multiple requests writing to a shared global resource causes race conditions, potentially resulting in Denial of Service (DoS) due to file locking errors, data corruption, and unauthorized file modification. Additionally, the hardcoded path disclosed internal system structures.
🔧 **Fix:** Removed the global `TextFile` handler variable and all associated legacy debug statements (`AssignFile`, `WriteLn`, `CloseFile`) from the production request handler.
✅ **Verification:** Verified through manual code review that the global variable and debug I/O logic are fully removed without altering the primary route behavior. Recorded this specific concurrency pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5218122724917594040](https://jules.google.com/task/5218122724917594040) started by @macgayverarmini*