### PR TITLE
⚡ Bolt: [performance improvement] Optimize base64 stream conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Stream and String Optimization in Pascal
+**Learning:** In Free Pascal/Delphi, passing the same inline function call multiple times as arguments to a procedure (e.g., `Result.WriteBuffer(base64.EncodeStringBase64(A)[1], Length(base64.EncodeStringBase64(A)))`) causes the compiler to evaluate the function redundantly. Also, unnecessary string-to-bytes-to-string round-trips via `TEncoding.UTF8.GetBytes` and `GetString` add redundant memory allocation when working with native strings and streams.
+**Action:** Store the result of expensive computations in a local variable before use in procedure calls. Use native string types directly with `TMemoryStream.ReadBuffer` and `WriteBuffer` instead of allocating intermediate `TBytes` arrays.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,48 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then Exit('');
+
+  // Optimization: Read directly into native string buffer instead of allocating TBytes array
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
+
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  Base64EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+
+  if Length(AString) > 0 then
+  begin
+    // Optimization: Avoid duplicate EncodeStringBase64 evaluation in WriteBuffer arguments
+    // Avoid TEncoding.UTF8 GetBytes -> GetString roundtrip
+    Base64EncodedStr := base64.EncodeStringBase64(AString);
+    if Length(Base64EncodedStr) > 0 then
+      Result.WriteBuffer(Base64EncodedStr[1], Length(Base64EncodedStr));
+  end;
+
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then Exit('');
+
+  // Optimization: Read directly into native string buffer instead of allocating TBytes array
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strContent[1], AStream.Size);
+
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +87,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Optimize base64 stream conversions

* **What**: Refactored `tools/streamtools.pas` to read binary streams directly into native string buffers using `ReadBuffer` instead of intermediate `TBytes` arrays. Also avoided redundant inline function evaluation (`EncodeStringBase64`) in `WriteBuffer` calls and removed the `TEncoding.UTF8.GetBytes/GetString` round-trip in `StringToBase64Stream`.
* **Why**: The Free Pascal compiler evaluates inline function parameters redundantly when passed multiple times, and allocating/deallocating intermediate byte arrays for base64 strings causes unnecessary memory allocations and CPU overhead on high throughput serialization paths.
* **Impact**: Improves performance during stream-to-base64 conversions and prevents possible out-of-bounds index errors on empty streams/strings. Memory allocations and redundant decoding operations are reduced.
* **Measurement**: Verified manually via logic inspection and checking `git diff` that no behavior changes occurred except for the optimized allocation path. Checked that bounds checking (`Length > 0`) was added to prevent `[1]` index out-of-bounds on empty inputs.

---
*PR created automatically by Jules for task [1046014659525531314](https://jules.google.com/task/1046014659525531314) started by @macgayverarmini*