### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded log path and concurrency DoS risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-09 - Fix DoS risk due to global file descriptor in HTTP route
+
+**Vulnerability:** A global file descriptor (`var F: TextFile;`) and hardcoded file path (`C:\NFMonitor\src\bin\log_debug.txt`) were used to write debug logs inside an HTTP route handler (`PostNFe`).
+**Learning:** Using global state such as file descriptors across concurrent web requests can lead to race conditions, I/O blocking, and Denial of Service (DoS) when multiple requests attempt to open or write to the same file simultaneously. The hardcoded path also created a directory traversal/path issue on systems without that specific directory structure.
+**Prevention:** Avoid defining variables globally within web route units. Ensure any logging uses proper concurrency-safe logging mechanisms (e.g. thread-safe log queues) and avoid writing raw text files directly in request handlers. Hardcoded paths should be avoided in favor of parameterized configurations.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,13 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🎯 **What**
This PR removes a legacy global file descriptor (`var F: TextFile;`) and hardcoded file path debugging block from `routes/route.acbr.nfe.pas`. 

⚠️ **Risk**
Defining a file descriptor globally in a web route implementation and attempting to write to a hardcoded path (`C:\NFMonitor\src\bin\log_debug.txt`) during concurrent incoming requests presents a significant risk of I/O blocking and a Denial of Service (DoS) vulnerability.

🛡️ **Solution**
Removed the global text file descriptor and the nested `try..except` blocks that attempted to open and write to the debug file. I have also added an entry to `.jules/sentinel.md` documenting this anti-pattern. Manual code review was conducted to verify functionality because `fpc`/`lazbuild` are not available in the sandbox environment.

---
*PR created automatically by Jules for task [9619340765048729833](https://jules.google.com/task/9619340765048729833) started by @macgayverarmini*