### PR TITLE
⚡ Bolt: [performance improvement] optimize streamtools base64 functions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Optimize Stream Read/Write via Native Strings in Lazarus/FPC
+**Learning:** Using `TBytes` combined with `TEncoding.UTF8.GetString` or `GetBytes` is unnecessary when working with streams and native strings in Pascal/FPC. It creates an intermediate heap allocation and performs a redundant copy.
+**Action:** When interacting with streams in Lazarus/FPC, use native string types directly with `TMemoryStream.ReadBuffer` and `WriteBuffer` (e.g., `AStream.ReadBuffer(str[1], AStream.Size)`) instead of allocating intermediate `TBytes` arrays. Always verify length is greater than 0 before indexing.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,35 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  strBase64: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  strBase64 := base64.EncodeStringBase64(AString);
+  if Length(strBase64) > 0 then
+    Result.WriteBuffer(strBase64[1], Length(strBase64));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +74,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
## 💡 What:
Optimized base64 stream conversions in `tools/streamtools.pas` by reading/writing directly from/to stream using native string buffers. Added safety checks for `Length > 0` to prevent range checks, and removed redundant double computations of base64 encoding during stream writing.

## 🎯 Why:
The original implementation had several performance flaws:
1. `StringToBase64Stream` was computing `base64.EncodeStringBase64` twice per write.
2. `Base64StreamToString` and `StreamToBase64String` allocated a `TBytes` intermediate array to read from the stream, and then copied that array to a string using `TEncoding.UTF8.GetString` before passing it to the base64 functions.

By directly leveraging 1-based native strings and removing intermediate arrays, we decrease redundant array allocations and unnecessary deep copying.

## 📊 Impact:
- Reduces peak memory usage for large streams (no duplicate allocations).
- Substantially improves string-to-stream encoding speed by removing the O(N) duplicate execution of the base64 encoding algorithm.
- Bypasses redundant UTF-8 bytes-to-string roundtripping.

## 🔬 Measurement:
Observe memory allocations and CPU cycles when serializing large base64 strings or files via `TestStreamTools`. Correctness remains unchanged.

---
*PR created automatically by Jules for task [8595610346075898841](https://jules.google.com/task/8595610346075898841) started by @macgayverarmini*