### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize Base64 Stream Handling
+**Learning:** In Free Pascal/Delphi, translating data streams directly to native string buffers is much more efficient than using intermediate `TBytes` arrays via `TEncoding.UTF8.GetString` and `GetBytes`. Additionally, duplicate inline function calls inside procedures (like `WriteBuffer(Func()[1], Length(Func()))`) cause redundant evaluations (O(2n)).
+**Action:** Always read/write directly to string buffers using `SetLength` and `ReadBuffer`/`WriteBuffer`, checking for non-zero lengths first to prevent out-of-bounds exceptions (`str[1]`). Cache results of expensive encoding operations in local variables rather than re-evaluating them inline.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,43 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if AStream.Size = 0 then Exit;
+  // ⚡ Bolt: Read directly into string buffer to avoid TBytes allocation
+  // and TEncoding.UTF8.GetString roundtrip.
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // ⚡ Bolt: Removed redundant UTF8 string-to-bytes-to-string round-trip.
+  // Cached EncodeStringBase64 result to avoid redundant O(2n) evaluations.
+  EncodedStr := base64.EncodeStringBase64(AString);
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strRaw: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if AStream.Size = 0 then Exit;
+  // ⚡ Bolt: Read directly into string buffer to avoid TBytes allocation
+  // and TEncoding.UTF8.GetString roundtrip.
+  SetLength(strRaw, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strRaw[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strRaw);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;


### PR DESCRIPTION
💡 What:
Optimized `StringToBase64Stream`, `Base64StreamToString`, and `StreamToBase64String` in `tools/streamtools.pas`. Removed inefficient intermediate byte arrays and `TEncoding.UTF8` encodings. Stream operations now read directly into properly sized string buffers via `AStream.ReadBuffer`. Cached inline function results that were previously evaluated twice (e.g., `Length()` vs `[1]`). Added early exits on size zero to avoid out-of-bounds indexing string bounds check errors.

🎯 Why:
The original implementations suffered from redundant string-to-bytes-to-string roundtrips (`TEncoding.UTF8.GetString`), unnecessary heap allocations for `TBytes` arrays, and duplicate evaluations of the expensive `base64.EncodeStringBase64` function resulting in O(2n) processing per call.

📊 Impact:
Reduces CPU cycles and memory allocations required for Base64 encoding/decoding during stream conversions, cutting down garbage generation. O(2n) processing in `StringToBase64Stream` is halved to O(n).

🔬 Measurement:
To verify the improvement, generate PDF/XML payloads using the ACBr webservice endpoints; observed memory profiling during high concurrent load should show reduced pressure from large array allocations. Tests suites involving base64 parsing remain functional.

---
*PR created automatically by Jules for task [12047940955367781626](https://jules.google.com/task/12047940955367781626) started by @macgayverarmini*