### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded debug log path and global file descriptor concurrency

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Concurrency and Hardcoded Path Vulnerabilities in Web Routes
+**Vulnerability:** Global file descriptors (e.g., `var F: TextFile;`) were declared globally in route implementations, creating thread-safety and concurrency issues for concurrent web requests. In addition, these were writing to a hardcoded Windows path (`C:\NFMonitor\src\bin\log_debug.txt`). This can lead to denial-of-service, unintended information leakage, or crash issues on systems where the path doesn't exist or concurrent execution clobbers the file.
+**Learning:** In a multi-threaded web environment like the Horse framework, avoid declaring file descriptors or shared state globally. Also, legacy debug code leaving hardcoded paths is a significant risk.
+**Prevention:** Always scope variables as locally as possible within procedures or functions. Remove `try...except` debug code blocks writing to hardcoded paths before shipping to production. If logging is required, use centralized and configurable logging strategies (e.g., environment variables for paths) and thread-safe approaches.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,13 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Global file descriptors (`var F: TextFile;`) were declared globally in route implementations, creating thread-safety and concurrency issues for concurrent web requests. In addition, these were writing to a hardcoded Windows path (`C:\NFMonitor\src\bin\log_debug.txt`).
🎯 Impact: This can lead to denial-of-service, unintended information leakage, or crash issues on systems where the path doesn't exist or concurrent execution clobbers the file in a multi-threaded web environment like the Horse framework.
🔧 Fix: Removed the globally scoped `var F: TextFile;` and completely eradicated the legacy `try...except` block writing to the hardcoded log file.
✅ Verification: Confirmed via `grep` that `var F: TextFile;` and `AssignFile` no longer exist in `routes/route.acbr.nfe.pas`. Verified the correct journaling format in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17573101689300602305](https://jules.google.com/task/17573101689300602305) started by @macgayverarmini*