### PR TITLE
🛡️ Sentinel: [HIGH] Fix global file descriptor and hardcoded path vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2024-05-27 - Removal of Global File Descriptor in Web Routes
+
+**Vulnerability:**
+Global variable `var F: TextFile;` declared in the implementation section of `routes/route.acbr.nfe.pas`, combined with hardcoded debug file paths `C:\NFMonitor\src\bin\log_debug.txt` and generic `try..except` suppression.
+
+**Learning:**
+Declaring global file descriptors in web frameworks like Horse leads to concurrency issues/race conditions, as multiple concurrent requests would attempt to `AssignFile`, `Rewrite`/`Append`, and write to the same global descriptor simultaneously, potentially corrupting logs or causing file lock crashes (DoS). Additionally, the use of hardcoded debug paths exposes path logic and could leak sensitive information if debug log files are compromised.
+
+**Prevention:**
+Always keep variables, particularly file descriptors and objects, within the scope of the method handling the HTTP request. Never commit temporary/hardcoded file paths or raw `TextFile` I/O blocks into production route handlers. Use standard framework or systemic logging configurations instead of direct file manipulations within routes.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,13 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Global file descriptor (`var F: TextFile;`) used in the implementation section of `routes/route.acbr.nfe.pas`, combined with writing logs to a hardcoded path (`C:\NFMonitor\src\bin\log_debug.txt`). This creates a significant race condition/DoS vulnerability in a multi-threaded web application context.
🎯 Impact: Concurrent requests hitting `PostNFe` would simultaneously attempt to access the same global file descriptor, causing lock violations, corruption, or process crashes (Denial of Service). Additionally, hardcoded file paths expose directory logic and could cause path errors in generic production environments.
🔧 Fix: Completely removed the global `var F: TextFile;` and the associated legacy `try..except` logging blocks writing to the hardcoded `C:\NFMonitor` directory.
✅ Verification: Ensured the removal of the specific lines using `sed` and `grep` so that the `TextFile` logic no longer exists in `routes/route.acbr.nfe.pas`. Checked that the overarching logic for processing and returning the response JSON in the route is maintained. Documented finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16219262948320309932](https://jules.google.com/task/16219262948320309932) started by @macgayverarmini*