### PR TITLE
⚡ Bolt: Optimize Base64 Stream Handling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-27 - Stream performance optimization and caching in Pascal
+**Learning:** Found redundant function evaluations in inline Pascal code (e.g., passing `Encode(...)` multiple times as arguments) and unnecessary string-to-bytes roundtripping in stream methods using `TEncoding.UTF8`.
+**Action:** Always store the result of expensive functions like `EncodeStringBase64` in a local variable before using them as arguments, especially with stream operations. Also, prefer direct native string type operations like `ReadBuffer` and `WriteBuffer` over `TBytes` buffer conversions to reduce memory usage and avoid roundtrip overhead.

--- a/test_stream_optimization.pas
+++ b/test_stream_optimization.pas
@@ -1,0 +1,9 @@
+program test_stream_optimization;
+
+{$mode Delphi}
+
+uses Classes, SysUtils, Base64, streamtools;
+
+begin
+  Writeln('Testing...');
+end.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,38 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt: Removed TBytes allocation and TEncoding.UTF8 round-trip. Using direct native string read.
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // ⚡ Bolt: Removed TBytes round-trip. Cached result of EncodeStringBase64 to prevent redundant evaluation.
+  EncodedStr := base64.EncodeStringBase64(AString);
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt: Removed TBytes allocation and TEncoding.UTF8 round-trip. Using direct native string read.
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +77,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 What: Refactored `tools/streamtools.pas` to replace intermediate `TBytes` buffer allocations and costly UTF-8 string roundtripping with direct reads into native strings using `ReadBuffer`/`WriteBuffer`. Also cached the result of `EncodeStringBase64` to avoid redundant O(N) evaluations in inline arguments.
🎯 Why: Frequent file and string Base64 encoding/decoding during API requests was triggering unnecessary memory allocations and redundant calculations.
📊 Impact: Expected reduction in memory spikes during file uploads/downloads and faster API response times due to $O(N)$ string processing speedup. 
🔬 Measurement: Verify changes in `tools/streamtools.pas`. Due to the missing FPC compiler on the system, automated execution of `TestStreamTools` could not be run, but standard Lazarus compile should verify correctly.

---
*PR created automatically by Jules for task [11070241377888868210](https://jules.google.com/task/11070241377888868210) started by @macgayverarmini*