### PR TITLE
⚡ Bolt: Optimize Base64 stream memory allocations and duplicate evaluations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Optimize Stream Operations
+**Learning:** Found redundant evaluations of `base64.EncodeStringBase64` and unnecessary `TEncoding.UTF8.GetBytes/GetString` round-trips when reading/writing from `TMemoryStream` objects in Pascal. Modern FPC string variables can be read from and written directly to streams (`AStream.ReadBuffer(str[1], AStream.Size)`), negating the need for expensive `TBytes` buffer allocations.
+**Action:** When working with Pascal streams, use native strings and `ReadBuffer/WriteBuffer` directly. Also cache expensive functional operations in local variables to prevent O(N) duplicate evaluations inside parameter lists.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,38 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt Optimization: Use native string directly with ReadBuffer instead of TBytes/UTF8 conversion
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  SetLength(strBase64, AStream.Size);
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  encodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // ⚡ Bolt Optimization: Avoid unnecessary TEncoding.UTF8 round-trips and cache encoded string to prevent duplicate evaluation
+  encodedStr := base64.EncodeStringBase64(AString);
+  if Length(encodedStr) > 0 then
+    Result.WriteBuffer(encodedStr[1], Length(encodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt Optimization: Use native string directly with ReadBuffer instead of TBytes/UTF8 conversion
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  SetLength(strContent, AStream.Size);
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +77,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 What: 
Removed unnecessary intermediate TBytes allocations and UTF-8 round-trips (`GetBytes`/`GetString`) across three Base64 conversion functions in `tools/streamtools.pas`. 
Cached the result of the expensive `base64.EncodeStringBase64` operation in `StringToBase64Stream` to avoid duplicating O(N) evaluation inside the `.WriteBuffer()` parameter list.
Now reads raw base64 bytes directly into the modern native 8-bit strings utilizing `ReadBuffer`. 

🎯 Why: 
In FPC, strings already function effectively as 8-bit byte arrays. Going back and forth through `TEncoding.UTF8` required allocating dynamic arrays and wasting CPU cycles to process identical byte values. Furthermore, by evaluating `base64.EncodeStringBase64()` twice in one parameter list, we were doubling the encode execution time. 

📊 Impact: 
Reduces memory allocation overhead by entirely avoiding `TBytes` creation. Reduces execution time for `StringToBase64Stream` by half by preventing duplicate base64 string encoding calls.

🔬 Measurement:
Run the stream base64 conversion test suite and verify no regressions exist, while load testing would show drastically reduced object allocations per request.

---
*PR created automatically by Jules for task [12046087061831821114](https://jules.google.com/task/12046087061831821114) started by @macgayverarmini*