### PR TITLE
🛡️ Sentinel: [HIGH] Fix global file descriptor concurrency vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Avoid global file descriptors in web routes
+**Vulnerability:** A global `var F: TextFile;` was declared in `routes/route.acbr.nfe.pas` and used in `PostNFe` for logging. This creates concurrency issues in a web server handling multiple requests concurrently, potentially leading to race conditions, file locking errors, or Denial of Service (DoS). Furthermore, it logs to a hardcoded local path `C:\NFMonitor\src\bin\log_debug.txt` creating an insecure direct object reference to the file system.
+**Learning:** Legacy debugging code with global state and hardcoded paths left in production web routes poses security and stability risks.
+**Prevention:** Never use global variables for request-level state (like file handles) in web frameworks. Remove legacy debugging code before merging, or use a proper logging framework.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A global `var F: TextFile;` was used across concurrent requests to write to a hardcoded local file (`C:\NFMonitor\src\bin\log_debug.txt`). This violates thread safety for web routes, creates race conditions leading to file lock errors, and potentially allows an attacker to DoS the endpoint.
🎯 **Impact:** Concurrent API requests triggering `PostNFe` could fail or crash the thread handling the request. It also hardcodes a path which could expose internals.
🔧 **Fix:** Removed the legacy debugging `AssignFile` blocks entirely from the route handler and eliminated the global variable state.
✅ **Verification:** Verified by checking that `TextFile` and `AssignFile` are fully removed from `route.acbr.nfe.pas`.

---
*PR created automatically by Jules for task [9485245863069114148](https://jules.google.com/task/9485245863069114148) started by @macgayverarmini*