### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix global file descriptor DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-06-01 - Global File Descriptor DoS Risk and Information Disclosure
+
+**Vulnerability:** A global file descriptor `var F: TextFile;` was declared in the `implementation` section of `routes/route.acbr.nfe.pas`, and it was used with a hardcoded path (`C:\NFMonitor\src\bin\log_debug.txt`) for debugging in a web route (`PostNFe`).
+**Learning:** In a multithreaded web application framework (like Horse), concurrent requests accessing the same global file descriptor will cause race conditions, access violations, or application crashes, leading to a Denial of Service (DoS). Additionally, writing to hardcoded external paths can expose sensitive application logic or system configurations, and it will crash if the directory does not exist or lacks proper permissions.
+**Prevention:** Never declare file descriptors globally in route handlers. Remove legacy debug code before committing. If logging is required, use thread-safe logging mechanisms (like structured logging to standard output) rather than manual file operations. If a file must be written, use configurable paths with dynamic, non-colliding names.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,13 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A global file descriptor `var F: TextFile;` was declared in the web route unit (`routes/route.acbr.nfe.pas`) and used concurrently inside `PostNFe` to log to a hardcoded Windows path (`C:\NFMonitor\src\bin\log_debug.txt`).
🎯 **Impact**: In a multi-threaded web application, using a global file descriptor without synchronization causes race conditions, leading to data corruption, access violations, or application crashes (Denial of Service). Furthermore, the hardcoded path could lead to an application crash on non-Windows environments and risks exposing application logic if accessible.
🔧 **Fix**: Removed the global file descriptor and the ad-hoc debug `AssignFile`/`WriteLn` logic entirely, which cleans up the endpoint without breaking business logic.
✅ **Verification**: Code analysis (`cat`, `sed`) verifies the variables and related `try..except` debug blocks were fully removed, preserving the core functionality (`LJson := Ac.NFe(O);`). Test compilation was attempted but environment lacked fpc.

---
*PR created automatically by Jules for task [13819415571625185586](https://jules.google.com/task/13819415571625185586) started by @macgayverarmini*