### PR TITLE
⚡ Bolt: Prevent redundant base64 encoding and string round-trips

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-08 - Prevent redundant base64 encoding and string round-trips
+**Learning:** Found that string-to-bytes conversions via TEncoding.UTF8 are redundant when dealing with operations that natively accept string inputs, such as base64.EncodeStringBase64, and repeating function calls as array index and string length parameters can be optimized by evaluating the function once into a local variable. Found that native stream buffering works faster directly on strings via ReadBuffer.
+**Action:** Always verify if intermediate TBytes allocations and recurrent string-to-bytes-to-string conversions can be refactored into direct string processing using native index 1-based buffering, and assign repetitive function evaluations to a local variable.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,39 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Optimization: use native string buffering instead of intermediate TBytes allocation
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
+  // Optimization: store base64 encode result to avoid redundant O(N) evaluation
+  // and remove redundant UTF8 conversions since AString can be encoded directly
+  EncodedStr := base64.EncodeStringBase64(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Optimization: use native string buffering instead of intermediate TBytes allocation
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  if AStream.Size > 0 then
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strBase64);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +78,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:** 
- Refactored `StringToBase64Stream` to store `base64.EncodeStringBase64` output in a local string to avoid redundant O(N) evaluation.
- Refactored `Base64StreamToString` and `StreamToBase64String` to read buffers directly into a string, eliminating intermediate `TBytes` allocations.
- Bypassed unnecessary `TEncoding.UTF8.GetString` and `GetBytes` loops.

🎯 **Why:** 
String-to-bytes conversions are slow and memory-intensive. Repeated evaluations of expensive Base64 processing inside `Length()` and memory writes multiply the CPU overhead. Writing straight to a natively sized buffer handles standard Pascal string memory management more efficiently.

📊 **Impact:** 
Substantial reduction in memory allocations (preventing garbage collector/allocator pressure) and CPU cycle savings for streaming and encoding large documents (like NFe XML/PDF streams). Eliminates the O(N) penalty of repeated base64 loops.

🔬 **Measurement:** 
Load times for large endpoints using Base64 data (like PDF printing generation). Verified correct functionality and implementation using manual code inspection.

---
*PR created automatically by Jules for task [1079441952606054352](https://jules.google.com/task/1079441952606054352) started by @macgayverarmini*