### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix hardcoded debug log and global file descriptor in routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-09 - Remove legacy hardcoded debugging logs to prevent DoS and info exposure
+**Vulnerability:** A global file descriptor `var F: TextFile;` and hardcoded path `C:\NFMonitor\src\bin\log_debug.txt` were used inside `try...except` blocks within the `PostNFe` web route in `routes/route.acbr.nfe.pas`.
+**Learning:** Using global file descriptors in route handlers creates concurrency issues that can lead to Denial of Service (DoS) under load. Furthermore, writing to hardcoded external paths like `C:\NFMonitor\...` without proper configuration risks unauthorized information disclosure and path errors in deployment.
+**Prevention:** Remove legacy local debugging mechanisms from production code. If logging is needed, use standard asynchronous logging libraries without globally shared non-thread-safe resources and rely on configurable paths.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Remove hardcoded debug file logging from PostNFe route
<code>🐞 Bug fix</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** A global file descriptor `var F: TextFile;` and hardcoded path `C:\NFMonitor\src\bin\log_debug.txt` were used inside `try...except` blocks within the `PostNFe` web route in `routes/route.acbr.nfe.pas`.
🎯 **Impact:** Using global file descriptors in route handlers creates concurrency issues that can lead to Denial of Service (DoS) under load. Furthermore, writing to hardcoded external paths like `C:\NFMonitor\...` without proper configuration risks unauthorized information disclosure and path errors in deployment.
🔧 **Fix:** Removed the legacy debugging statements and the global file descriptor.
✅ **Verification:** Verified patch via explicit review and tests. Also updated the `.jules/sentinel.md` journal with this learning.

---
*PR created automatically by Jules for task [5488537780808638936](https://jules.google.com/task/5488537780808638936) started by @macgayverarmini*

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Remove legacy debug writes to a hardcoded local file from the PostNFe route.
• Eliminate a global TextFile descriptor to avoid concurrency/race issues under load.
• Record the security learning and prevention guidance in the Sentinel journal.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Client"] --> B["Horse route: PostNFe"] --> C["Parse JSON body"] --> D["Create TACBRBridgeNFe"] --> E["Call Ac.NFe"] --> F["Send JSON response"]
  X["Removed: hardcoded file debug logging"] -.-> B
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Replace with framework logger (thread-safe, configurable path)</b></summary>

- ➕ Retains observability without introducing global shared state
- ➕ Avoids hardcoded absolute paths; supports deployment-specific configuration
- ➕ Can add per-request correlation IDs and log levels
- ➖ Slightly larger change (new dependency/config surface)
- ➖ Requires deciding logging policy/format and rotation strategy

</details>

<details>
<summary><b>2. Guard debug logging behind build flag/env var</b></summary>

- ➕ Keeps optional diagnostics for local troubleshooting
- ➕ Minimal runtime overhead when disabled
- ➖ Still easy to accidentally enable in production
- ➖ Does not inherently solve safe log sink selection unless paired with proper logger

</details>

**Recommendation:** For a security hotfix, removing the global TextFile and hardcoded path is the right minimal-risk approach. If runtime diagnostics are still needed, follow up by introducing a standard thread-safe logger with configurable sinks/paths rather than ad-hoc file I/O inside route handlers.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>route.acbr.nfe.pas</strong> <code>Remove global TextFile and hardcoded debug log writes from PostNFe</code> <code>+596/-612</code></summary>

<br/>

>Remove global TextFile and hardcoded debug log writes from PostNFe
>
><pre>
>• Deletes the global &#x27;var F: TextFile;&#x27; and removes the two &#x27;try...except&#x27; blocks that wrote route timing messages to &#x27;C:\NFMonitor\src\bin\log_debug.txt&#x27;. The PostNFe route now only executes the ACBr call and returns the JSON response, avoiding shared mutable state and unsafe filesystem writes.
></pre>
>
><a href='https://github.com/macgayverarmini/ACBRWebService/pull/106/files#diff-b5deef90a038d2efa44b27173da73c5606c2211e79f23029b43b3b705d330c81'>routes/route.acbr.nfe.pas</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>sentinel.md</strong> <code>Add Sentinel journal entry documenting the logging vulnerability</code> <code>+4/-0</code></summary>

<br/>

>Add Sentinel journal entry documenting the logging vulnerability
>
><pre>
>• Adds a dated entry capturing the issue (global TextFile + hardcoded debug path), the concurrency/info-exposure risk, and recommended prevention (use standard configurable logging).
></pre>
>
><a href='https://github.com/macgayverarmini/ACBRWebService/pull/106/files#diff-92c8ea7491b8afdf97b053a12e7f4f811041aa6b960c19005077c840ca892922'>.jules/sentinel.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>