### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS and Information Disclosure in ACBR NFe Routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-12 - Critical DoS and Info Disclosure in ACBR NFe Routes
+**Vulnerability:** Globally declared `TextFile` variables used within HTTP request handlers and hardcoded local debug file paths (`C:\NFMonitor\src\bin\log_debug.txt`).
+**Learning:** In a web application processing concurrent HTTP requests, sharing a global file descriptor (e.g., `var F: TextFile;`) causes race conditions that can crash the service or lead to Denial of Service (DoS). Additionally, dumping request execution flow to a fixed, guessable hardcoded path leaks sensitive operational information and is vulnerable to path traversal or arbitrary file overwrite.
+**Prevention:** Always encapsulate file operations within local scope (or avoid them entirely in production HTTP routes) and never use hardcoded absolute file paths. Use configurable, dynamic, and secure logging mechanisms instead.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,8 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
@@ -175,26 +173,12 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
-
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Globally scoped `TextFile` variables used within concurrent HTTP request handlers, and execution flow dumped to hardcoded, fixed local paths (`C:\NFMonitor\src\bin\log_debug.txt`).
🎯 Impact: High probability of Denial of Service (DoS) due to concurrent requests trying to lock the same file descriptor, plus arbitrary file overwrite/information disclosure risks from writing debug output to absolute deterministic paths in a production endpoint.
🔧 Fix: Removed the globally scoped `var F: TextFile;` and removed the legacy `try..except` file I/O blocks inside the `PostNFe` web route handler.
✅ Verification: Manually verified through file inspection that `route.acbr.nfe.pas` no longer contains the vulnerability.

---
*PR created automatically by Jules for task [13292821844945039582](https://jules.google.com/task/13292821844945039582) started by @macgayverarmini*