### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix concurrent file access and path traversal risk in NFe route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-15 - Concurrent file access and path traversal risk in web routes
+**Vulnerability:** A global file descriptor (`var F: TextFile;`) and hardcoded file path (`C:\NFMonitor\src\bin\log_debug.txt`) were used for debugging in the `PostNFe` web route handler.
+**Learning:** In a multi-threaded web environment (like Horse), global variables used for I/O create concurrency issues and potential DoS risks. Hardcoded absolute Windows paths in legacy code can cause path traversal issues, file not found errors in other environments, and potentially sensitive information disclosure in arbitrary locations.
+**Prevention:** Avoid global variables in web route handlers. Do not leave temporary file-based debugging blocks in production code. Use configurable paths or standard logging frameworks instead of hardcoded paths.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,7 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
+
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +175,14 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
 
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: A global file descriptor `var F: TextFile` was used to write to a hardcoded path (`C:\NFMonitor\src\bin\log_debug.txt`) for debugging in a web route handler (`PostNFe`).
🎯 Impact: In a multi-threaded web environment (Horse), this global state could cause concurrency issues (a race condition), locking errors, or thread crashes under load, potentially leading to a Denial of Service. The hardcoded absolute Windows path also poses a minor path traversal risk if maliciously manipulated, and causes path-not-found errors in non-Windows environments.
🔧 Fix: Removed the `TextFile` global variable declaration and deleted the `try...except` debugging snippets from `routes/route.acbr.nfe.pas`. Recorded the learning in `.jules/sentinel.md`.
✅ Verification: Code reviewed manually; no syntax or structural issues introduced. Tests were skipped due to missing compiler, but visual verification confirmed the targeted, isolated removal.

---
*PR created automatically by Jules for task [12408276648707874383](https://jules.google.com/task/12408276648707874383) started by @macgayverarmini*