### PR TITLE
⚡ Bolt: [performance improvement] Optimize stream and base64 string conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Stream and Base64 String Optimizations
+**Learning:** Native Pascal strings can be used directly with `TMemoryStream.ReadBuffer` and `WriteBuffer` (e.g., `AStream.ReadBuffer(str[1], AStream.Size)`), avoiding intermediate `TBytes` array allocations and expensive `TEncoding.UTF8` conversions. Also, passing inline function calls like `base64.EncodeStringBase64` multiple times to `WriteBuffer` causes redundant evaluations.
+**Action:** Always read/write streams directly into string buffers when dealing with base64/text streams, and store results of expensive inline function calls in local variables before using them as arguments to `WriteBuffer`.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,40 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Optimization: Read directly into a string buffer to avoid allocating intermediate TBytes and TEncoding.UTF8 overhead.
+  if AStream.Size = 0 then
+    Exit('');
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
+  // Optimization: Removed redundant base64 encoding calls and TEncoding byte conversions.
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  EncodedStr := base64.EncodeStringBase64(AString);
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Optimization: Read directly into a string buffer instead of allocating TBytes.
+  if AStream.Size = 0 then
+    Exit('');
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strContent[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +79,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 What: Optimized stream-to-string and base64 encoding/decoding functions in `streamtools.pas` by directly reading from `TMemoryStream` into native Pascal strings and eliminating redundant encoding evaluations.
🎯 Why: `TMemoryStream` read/write operations previously allocated intermediate `TBytes` arrays and used expensive `TEncoding.UTF8.GetString` and `GetBytes` conversions unnecessarily. Furthermore, `StringToBase64Stream` evaluated the entire base64 encoding function twice inside the `WriteBuffer` call.
📊 Impact: Reduces memory allocations per stream conversion by avoiding duplicate byte arrays. Prevents redundant CPU cycles during base64 encoding, making operations measurably faster, especially for larger files like generated PDFs and XMLs.
🔬 Measurement: Can be observed by profiling `FileToStringBase64` and `Base64StreamToString` operations, which should show fewer `TEncoding` objects instantiated and faster execution times for large streams.

---
*PR created automatically by Jules for task [12621926156861426182](https://jules.google.com/task/12621926156861426182) started by @macgayverarmini*