### PR TITLE
⚡ Bolt: Refactor TRttiContext usage to eliminate redundant O(N) allocations in JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - TRttiContext Allocation Bottleneck
+**Learning:** In Free Pascal/Delphi, `TRttiContext.Create` is an expensive operation because it initializes and caches RTTI information. Instantiating it redundantly within loops or recursive serialization/deserialization routines causes severe overhead and O(N) allocations.
+**Action:** When using RTTI for deep JSON serialization/deserialization, create the `TRttiContext` once in the public entry points and pass it as a `const` parameter down the call stack to internal recursive functions to maximize performance.

--- a/tools/jsonconvert.pas
+++ b/tools/jsonconvert.pas
@@ -17,9 +17,10 @@ type
 
   TJSONTools = class
   private
-    class procedure PopulateObjectList(AListObj: TObject; AArray: TJSONArray);
-    class function InternalObjToJson(const Obj: TObject; Visited: TList): TJSONData;
-    class function ValueToJson(const Value: TValue; Visited: TList): TJSONData;
+    class procedure PopulateObjectList(AListObj: TObject; AArray: TJSONArray; const Ctx: TRttiContext);
+    class function InternalObjToJson(const Obj: TObject; Visited: TList; const Ctx: TRttiContext): TJSONData;
+    class function ValueToJson(const Value: TValue; Visited: TList; const Ctx: TRttiContext): TJSONData;
+    class procedure InternalJsonToObj(const Json: TJSONObject; const Obj: TObject; const Ctx: TRttiContext);
   public
     class function ObjToJsonString(const Obj: TObject): string;
     class function ObjToJson(const Obj: TObject): TJSONObject;
@@ -41,11 +42,10 @@ type
 
 { TJSONTools }
 
-class procedure TJSONTools.PopulateObjectList(AListObj: TObject; AArray: TJSONArray);
+class procedure TJSONTools.PopulateObjectList(AListObj: TObject; AArray: TJSONArray; const Ctx: TRttiContext);
 var
   I: Integer;
   LNewItem: TObject;
-  Ctx: TRttiContext;
   RttiType: TRttiType;
   RttiMethod: TRttiMethod;
 begin
@@ -68,38 +68,34 @@ begin
       begin
         LNewItem := TCollection(AListObj).Add;
         if Assigned(LNewItem) then
-          JsonToObj(TJSONObject(AArray.Items[I]), LNewItem);
+          InternalJsonToObj(TJSONObject(AArray.Items[I]), LNewItem, Ctx);
       end;
     end;
     Exit;
   end;
 
-  Ctx := TRttiContext.Create(False);
-  try
-    RttiType := Ctx.GetType(AListObj.ClassType);
-    if not Assigned(RttiType) then Exit;
+  // ⚡ Bolt optimization: using passed TRttiContext instead of creating a new one
+  RttiType := Ctx.GetType(AListObj.ClassType);
+  if not Assigned(RttiType) then Exit;
 
-    RttiMethod := RttiType.GetMethod('New');
-    if not Assigned(RttiMethod) then
-      RttiMethod := RttiType.GetMethod('NEW');
-    
-    if not Assigned(RttiMethod) then
-      RttiMethod := RttiType.GetMethod('new');
+  RttiMethod := RttiType.GetMethod('New');
+  if not Assigned(RttiMethod) then
+    RttiMethod := RttiType.GetMethod('NEW');
 
-    if Assigned(RttiMethod) then
+  if not Assigned(RttiMethod) then
+    RttiMethod := RttiType.GetMethod('new');
+
+  if Assigned(RttiMethod) then
+  begin
+    for I := 0 to AArray.Count - 1 do
     begin
-      for I := 0 to AArray.Count - 1 do
+      if AArray.Items[I] is TJSONObject then
       begin
-        if AArray.Items[I] is TJSONObject then
-        begin
-          LNewItem := RttiMethod.Invoke(AListObj, []).AsObject;
-          if Assigned(LNewItem) then
-            JsonToObj(TJSONObject(AArray.Items[I]), LNewItem);
-        end;
+        LNewItem := RttiMethod.Invoke(AListObj, []).AsObject;
+        if Assigned(LNewItem) then
+          InternalJsonToObj(TJSONObject(AArray.Items[I]), LNewItem, Ctx);
       end;
     end;
-  finally
-    Ctx.Free;
   end;
 end;
 
@@ -159,7 +155,7 @@ begin
     Result := '{}';
 end;
 
-class function TJSONTools.ValueToJson(const Value: TValue; Visited: TList): TJSONData;
+class function TJSONTools.ValueToJson(const Value: TValue; Visited: TList; const Ctx: TRttiContext): TJSONData;
 var
   Obj: TObject;
   EnumName: string;
@@ -197,16 +193,15 @@ begin
     tkClass:
       begin
         Obj := Value.AsObject;
-        Result := InternalObjToJson(Obj, Visited);
+        Result := InternalObjToJson(Obj, Visited, Ctx);
       end;
   else
     Result := TJSONNull.Create;
   end;
 end;
 
-class function TJSONTools.InternalObjToJson(const Obj: TObject; Visited: TList): TJSONData;
+class function TJSONTools.InternalObjToJson(const Obj: TObject; Visited: TList; const Ctx: TRttiContext): TJSONData;
 var
-  Ctx: TRttiContext;
   RttiType: TRttiType;
   Props: TRttiPropertyArray;
   Prop: TRttiProperty;
@@ -237,7 +232,7 @@ begin
       ArrJson := TJSONArray.Create;
       for i := 0 to TCollection(Obj).Count - 1 do
       begin
-        ArrJson.Add(InternalObjToJson(TCollection(Obj).Items[i], Visited));
+        ArrJson.Add(InternalObjToJson(TCollection(Obj).Items[i], Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
@@ -247,7 +242,7 @@ begin
       ArrJson := TJSONArray.Create;
       for i := 0 to TObjectList(Obj).Count - 1 do
       begin
-        ArrJson.Add(InternalObjToJson(TObjectList(Obj).Items[i], Visited));
+        ArrJson.Add(InternalObjToJson(TObjectList(Obj).Items[i], Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
@@ -258,34 +253,30 @@ begin
       for i := 0 to TList(Obj).Count - 1 do
       begin
         ItemObj := TObject(TList(Obj).Items[i]);
-        ArrJson.Add(InternalObjToJson(ItemObj, Visited));
+        ArrJson.Add(InternalObjToJson(ItemObj, Visited, Ctx));
       end;
       Exit(ArrJson);
     end;
 
     ObjJson := TJSONObject.Create;
     
-    Ctx := TRttiContext.Create(False);
-    try
-      RttiType := Ctx.GetType(Obj.ClassType);
-      if Assigned(RttiType) then
+    // ⚡ Bolt optimization: using passed TRttiContext instead of creating a new one per iteration
+    RttiType := Ctx.GetType(Obj.ClassType);
+    if Assigned(RttiType) then
+    begin
+      Props := RttiType.GetProperties;
+      for i := 0 to Length(Props) - 1 do
       begin
-        Props := RttiType.GetProperties;
-        for i := 0 to Length(Props) - 1 do
+        Prop := Props[i];
+        if Prop.IsReadable and (Prop.Visibility in [mvPublic, mvPublished]) then
         begin
-          Prop := Props[i];
-          if Prop.IsReadable and (Prop.Visibility in [mvPublic, mvPublished]) then
-          begin
-            try
-              Val := Prop.GetValue(Obj);
-              ObjJson.Add(Prop.Name, ValueToJson(Val, Visited));
-            except
-            end;
+          try
+            Val := Prop.GetValue(Obj);
+            ObjJson.Add(Prop.Name, ValueToJson(Val, Visited, Ctx));
+          except
           end;
         end;
       end;
-    finally
-      Ctx.Free;
     end;
 
     Result := ObjJson;
@@ -298,13 +289,16 @@ class function TJSONTools.ObjToJson(const Obj: TObject): TJSONObject;
 var
   Visited: TList;
   Data: TJSONData;
+  Ctx: TRttiContext;
 begin
   if Obj = nil then
     Exit(nil);
 
   Visited := TList.Create;
+  // ⚡ Bolt optimization: create context once and pass down to recursive calls
+  Ctx := TRttiContext.Create(False);
   try
-    Data := InternalObjToJson(Obj, Visited);
+    Data := InternalObjToJson(Obj, Visited, Ctx);
     if Data is TJSONObject then
       Result := TJSONObject(Data)
     else
@@ -313,6 +307,7 @@ begin
       Data.Free;
     end;
   finally
+    Ctx.Free;
     Visited.Free;
   end;
 end;
@@ -333,9 +328,8 @@ begin
   end;
 end;
 
-class procedure TJSONTools.JsonToObj(const Json: TJSONObject; const Obj: TObject);
+class procedure TJSONTools.InternalJsonToObj(const Json: TJSONObject; const Obj: TObject; const Ctx: TRttiContext);
 var
-  Ctx: TRttiContext;
   RttiType: TRttiType;
   Prop: TRttiProperty;
   i: Integer;
@@ -348,32 +342,30 @@ var
 begin
   if (Json = nil) or (Obj = nil) then Exit;
 
-  Ctx := TRttiContext.Create(False);
-  try
-    RttiType := Ctx.GetType(Obj.ClassType);
-    if not Assigned(RttiType) then Exit;
+  RttiType := Ctx.GetType(Obj.ClassType);
+  if not Assigned(RttiType) then Exit;
 
-    for i := 0 to Json.Count - 1 do
+  for i := 0 to Json.Count - 1 do
+  begin
+    PropStr := Json.Names[i];
+    JsonVal := Json.Items[i];
+    if JsonVal.IsNull then Continue;
+
+    Prop := RttiType.GetProperty(PropStr);
+    if Assigned(Prop) then
     begin
-      PropStr := Json.Names[i];
-      JsonVal := Json.Items[i];
-      if JsonVal.IsNull then Continue;
-
-      Prop := RttiType.GetProperty(PropStr);
-      if Assigned(Prop) then
+      if Prop.PropertyType.TypeKind = tkClass then
       begin
-        if Prop.PropertyType.TypeKind = tkClass then
+        Val := Prop.GetValue(Obj);
+        ObjRef := Val.AsObject;
+        if Assigned(ObjRef) then
         begin
-          Val := Prop.GetValue(Obj);
-          ObjRef := Val.AsObject;
-          if Assigned(ObjRef) then
-          begin
-            if JsonVal is TJSONObject then
-              JsonToObj(TJSONObject(JsonVal), ObjRef)
-            else if JsonVal is TJSONArray then
-              PopulateObjectList(ObjRef, TJSONArray(JsonVal));
-          end;
-        end
+          if JsonVal is TJSONObject then
+            InternalJsonToObj(TJSONObject(JsonVal), ObjRef, Ctx)
+          else if JsonVal is TJSONArray then
+            PopulateObjectList(ObjRef, TJSONArray(JsonVal), Ctx);
+        end;
+      end
         else if Prop.IsWritable then
         begin
           try
@@ -424,6 +416,18 @@ begin
         end;
       end;
     end;
+end;
+
+class procedure TJSONTools.JsonToObj(const Json: TJSONObject; const Obj: TObject);
+var
+  Ctx: TRttiContext;
+begin
+  if (Json = nil) or (Obj = nil) then Exit;
+
+  // ⚡ Bolt optimization: create context once and pass down to recursive calls
+  Ctx := TRttiContext.Create(False);
+  try
+    InternalJsonToObj(Json, Obj, Ctx);
   finally
     Ctx.Free;
   end;


### PR DESCRIPTION
💡 What: Refactored `TJSONTools` in `tools/jsonconvert.pas` to create `TRttiContext` once in public entry points and pass it as a `const` parameter down to internal recursive functions (like `InternalObjToJson` and `ValueToJson`), eliminating redundant context allocations.

🎯 Why: In Free Pascal/Delphi, `TRttiContext.Create` is an expensive operation as it initializes and caches RTTI structures. Doing this repeatedly inside recursive loops caused severe O(N) overhead during JSON serialization/deserialization.

📊 Impact: Reduces memory allocations and significantly speeds up JSON serialization and deserialization for deep or large object graphs, particularly when processing arrays of objects.

🔬 Measurement: Observe CPU profiling or execution times for `ObjToJson` / `JsonToObj` on complex nested objects; memory footprint and execution duration will be notably reduced. Code correctness verified via manual manual inspection and test assertions on JSON generation logic.

---
*PR created automatically by Jules for task [2854282139940052691](https://jules.google.com/task/2854282139940052691) started by @macgayverarmini*