### PR TITLE
🛡️ Sentinel: [HIGH] Fix global file descriptor concurrency vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-20 - Fix global file descriptor concurrency vulnerability
+**Vulnerability:** A global file descriptor `var F: TextFile;` was used in `route.acbr.nfe.pas` across a concurrent Horse route, which leads to race conditions and Denial-of-Service when multiple requests trigger the file logging logic simultaneously. Additionally, the log file hardcoded a Windows path (`C:\NFMonitor\src\bin\log_debug.txt`).
+**Learning:** Avoid declaring global file descriptors or similar stateful variables in web request handling logic.
+**Prevention:** Avoid legacy file logging using `AssignFile` in web apps and favor standard loggers. Also, do not hardcode absolute system paths.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,9 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
-
-
 function ExtractConfig(O: TJSONObject; const Field: string): string;
 var
   Data: TJSONData;
@@ -175,26 +172,13 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
-
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application used a global `var F: TextFile;` variable inside the `routes/route.acbr.nfe.pas` file. Because this is a web application using the Horse framework, multiple concurrent requests would race to access and write to the same `C:\NFMonitor\src\bin\log_debug.txt` file simultaneously, leading to file locking errors, unexpected log corruption, and a potential Denial-of-Service via application crashes. Additionally, hardcoded Windows absolute paths present a path disclosure risk.
🎯 **Impact:** Prevents race conditions and application crashes when multiple NFe API requests are received at the exact same time. Removes potential path leakage.
🔧 **Fix:** Removed the global `var F: TextFile;` variable completely and excised the legacy `AssignFile`/`WriteLn` try-except blocks surrounding the actual logic in `PostNFe` handler. The core business logic (`LJson := Ac.NFe(O);`) remains functionally intact and safely stateless.
✅ **Verification:** Verified by visually confirming the offending `AssignFile` and `TextFile` blocks no longer exist, making the endpoint fully stateless and concurrent-safe. Tests were manually skipped because compiler infrastructure wasn't available, but the refactor was purely subtractive of non-critical debug logic. Evaluated the new `.jules/sentinel.md` format.

---
*PR created automatically by Jules for task [15681946147705399095](https://jules.google.com/task/15681946147705399095) started by @macgayverarmini*