### PR TITLE
⚡ Bolt: [performance improvement] optimize Base64 stream conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize Base64 Stream Conversions
+**Learning:** In Free Pascal/Delphi, performing string conversions to `TBytes` (`TEncoding.UTF8.GetBytes` / `GetString`) when writing or reading from streams adds redundant O(N) allocation overhead. Furthermore, executing expensive functions like `EncodeStringBase64` inline within a procedure call like `WriteBuffer(Func()[1], Length(Func()))` causes redundant evaluation.
+**Action:** Always read streams directly into native strings using `ReadBuffer(str[1], AStream.Size)`, verify empty sizes to avoid bounds errors, and cache expensive function returns in local variables before referencing their lengths or elements.

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+fpc -Fu"resources/" -Fu"tests/unit/" -Fu"tools/" -Fu"routes/" -Fu"method/" -Mdelphi -Sh tests/test_rtti3.pas
+./tests/test_rtti3

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,42 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt: Removed TBytes allocation and TEncoding roundtrip, reading directly into string
+  if AStream.Size = 0 then
+    Exit('');
+
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  encodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
+  // ⚡ Bolt: Cached EncodeStringBase64 result to avoid calling O(N) inline function twice, removed redundant GetBytes/GetString
+  encodedStr := base64.EncodeStringBase64(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  if Length(encodedStr) > 0 then
+    Result.WriteBuffer(encodedStr[1], Length(encodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strRaw: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // ⚡ Bolt: Removed TBytes allocation and TEncoding roundtrip, reading directly into string
+  if AStream.Size = 0 then
+    Exit('');
+
+  SetLength(strRaw, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strRaw[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strRaw);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +81,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 What: Refactored `StringToBase64Stream`, `Base64StreamToString`, and `StreamToBase64String` in `tools/streamtools.pas` to read/write natively with strings and cache inline expensive function evaluations. Added safety checks for zero-byte streams.

🎯 Why: Inline evaluation of functions for both content and length arguments forces redundant evaluations in Pascal. Additionally, creating intermediate `TBytes` arrays for string encoding/decoding adds redundant O(N) allocation and garbage overhead in stream read/writes.

📊 Impact: Reduces memory allocations during stream processing and cuts the execution time of `StringToBase64Stream` substantially by halving the evaluations of the base64 encoding algorithm.

🔬 Measurement: Review the stream conversion source file to verify reduced allocations. This will impact performance positively anywhere files or PDF reports are exported as Base64 strings.

---
*PR created automatically by Jules for task [10841502850664018888](https://jules.google.com/task/10841502850664018888) started by @macgayverarmini*