### PR TITLE
⚡ Bolt: Optimize Base64 stream conversions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-06-24 - Optimize Stream Operations
+
+**Learning:** In Free Pascal/Lazarus, allocating intermediate `TBytes` arrays and using `TEncoding.UTF8.GetString` or `GetBytes` is unnecessary when working with streams and string data, leading to extra memory allocations and copying. Additionally, passing an expensive function call (like `EncodeStringBase64`) twice as inline arguments to a procedure evaluates it redundantly.
+
+**Action:** Read directly into native string types using `ReadBuffer(str[1], AStream.Size)` and ensure the stream size is checked for `> 0` first. When passing the result of an expensive function, cache it in a local variable before using it as a buffer and length.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,45 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if AStream.Size = 0 then Exit;
+
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  // ⚡ Bolt: Read directly into native string buffer to avoid TBytes allocations
+  // ⚡ Bolt: Use ReadBuffer instead of Read for safer error handling
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // ⚡ Bolt: Store expensive EncodeStringBase64 result in local var to avoid redundant calls
+  // ⚡ Bolt: Avoided unnecessary TEncoding.UTF8 round trips
+  EncodedStr := base64.EncodeStringBase64(AString);
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strStream: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  Result := '';
+  if AStream.Size = 0 then Exit;
+
+  SetLength(strStream, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  // ⚡ Bolt: Read directly into native string buffer to avoid TBytes allocations
+  // ⚡ Bolt: Use ReadBuffer instead of Read for safer error handling
+  AStream.ReadBuffer(strStream[1], AStream.Size);
+  Result := base64.EncodeStringBase64(strStream);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +84,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:** 
Optimized the Base64 stream conversion utilities (`Base64StreamToString`, `StringToBase64Stream`, and `StreamToBase64String`) in `tools/streamtools.pas`. 

🎯 **Why:** 
The original implementation unnecessarily allocated intermediate `TBytes` arrays and used `TEncoding.UTF8.GetString`/`GetBytes`, resulting in redundant string-to-bytes-to-string roundtrips and increased memory overhead. In `StringToBase64Stream`, the expensive `base64.EncodeStringBase64` function was called redundantly as inline parameters to `WriteBuffer`.

📊 **Impact:** 
Significantly reduces memory allocations and string copying overhead when dealing with large Base64 file streams (e.g., PDF generation). Eliminates redundant $O(N)$ Base64 encoding evaluations. Enhances safety by using `ReadBuffer` to fail fast on partial reads and checking `AStream.Size > 0` before indexing string arrays.

🔬 **Measurement:** 
Manual code review confirms memory overhead is approximately halved for stream conversions due to the elimination of `TBytes` arrays and UTF8 transcoding. Tests could not be evaluated explicitly via `TestRunner` as the FPC compiler is omitted from the restricted environment, but syntax has been manually confirmed.

---
*PR created automatically by Jules for task [2539674630274957678](https://jules.google.com/task/2539674630274957678) started by @macgayverarmini*