### PR TITLE
⚡ Bolt: Optimize Base64 stream string manipulations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Stream Handling Optimizations
+**Learning:** In Lazarus/FPC, interacting with streams via `TEncoding.UTF8.GetBytes` and `TEncoding.UTF8.GetString` introduces unnecessary overhead by allocating intermediate `TBytes` arrays. Also, passing the same inline function call multiple times as arguments causes the compiler to evaluate the function redundantly.
+**Action:** When handling stream parsing for basic encoded content like Base64, directly allocate string lengths and use `ReadBuffer(str[1], AStream.Size)` and `WriteBuffer(str[1], Length(str))` to avoid array copies. Cache expensive function results in local variables.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,47 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Bolt optimization: Directly read into native string, avoiding TBytes allocation via TEncoding.UTF8
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  if AStream.Size > 0 then
+  begin
+    SetLength(strBase64, AStream.Size);
+    AStream.ReadBuffer(strBase64[1], AStream.Size);
+  end
+  else
+    strBase64 := '';
+
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  EncodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  // Bolt optimization: Pre-compute encoded string to avoid redundant processing, write string directly to buffer
+  EncodedStr := base64.EncodeStringBase64(AString);
+  if Length(EncodedStr) > 0 then
+    Result.WriteBuffer(EncodedStr[1], Length(EncodedStr));
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  // Bolt optimization: Read directly into native string instead of intermediate TBytes
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  if AStream.Size > 0 then
+  begin
+    SetLength(strContent, AStream.Size);
+    AStream.ReadBuffer(strContent[1], AStream.Size);
+    Result := base64.EncodeStringBase64(strContent);
+  end
+  else
+    Result := '';
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +86,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:** Refactored `StringToBase64Stream`, `StreamToBase64String` and `Base64StreamToString` in `tools/streamtools.pas` to read and write directly to/from native strings instead of using intermediate `TBytes` arrays. Also pre-computed `EncodeStringBase64` inside `StringToBase64Stream` to avoid calculating it redundantly inside `Length()`.
🎯 **Why:** To improve performance and efficiency. Allocating `TBytes` arrays via `TEncoding.UTF8.GetString` and `.GetBytes` creates unnecessary memory allocations and copying overhead. Re-evaluating expensive encoding operations directly as arguments negatively impacts processing speed for binary files.
📊 **Impact:** Reduces redundant string/byte conversions to 0. Eliminates repeated `base64.EncodeStringBase64` operations when writing Base64 streams. Decreases memory footprints for streaming operations. 
🔬 **Measurement:** Code review verifies direct `ReadBuffer` and `WriteBuffer` calls into string indices. Testing the API payload processing should yield more consistent times due to less GC pressure and memory handling.

---
*PR created automatically by Jules for task [18262901274541232546](https://jules.google.com/task/18262901274541232546) started by @macgayverarmini*