### PR TITLE
⚡ Bolt: Optimize Base64 stream buffer processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-26 - Stream Buffer Direct String Manipulation
+**Learning:** Using `TEncoding.UTF8.GetBytes` and `GetString` to convert between streams and strings involves creating intermediate `TBytes` arrays and performing unnecessary string round-trips. Furthermore, making redundant inline calls to encoding/decoding functions as arguments to `WriteBuffer` forces O(N) evaluation twice.
+**Action:** Always prefer direct string buffer manipulation (`ReadBuffer(str[1], Size)` and `WriteBuffer(str[1], Length)`) to avoid intermediate array allocations. Also, cache the results of encoding functions into local variables before passing them to avoid redundant inline evaluations.

--- a/tools/streamtools.pas
+++ b/tools/streamtools.pas
@@ -16,34 +16,45 @@ implementation
 
 function Base64StreamToString(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
   strBase64: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then Exit('');
+
+  // Optimization: Read directly into native string buffer, avoiding TBytes/UTF8 conversion overhead
+  SetLength(strBase64, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  strBase64 := TEncoding.UTF8.GetString(LBytes);
+  AStream.ReadBuffer(strBase64[1], AStream.Size);
+
   Result := base64.DecodeStringBase64(strBase64);
 end;
 
 function StringToBase64Stream(AString: string): TMemoryStream;
 var
-  LBytes: TBytes;
+  encodedStr: string;
 begin
-  LBytes := TEncoding.UTF8.GetBytes(AString);
   Result := TMemoryStream.Create;
-  Result.WriteBuffer(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))[1], Length(base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes))));
+  if Length(AString) = 0 then Exit;
+
+  // Optimization: Cache result and use native string buffer to avoid redundant O(N) evaluation and TBytes allocation
+  encodedStr := base64.EncodeStringBase64(AString);
+  if Length(encodedStr) > 0 then
+    Result.WriteBuffer(encodedStr[1], Length(encodedStr));
+
   Result.Position := 0;
 end;
 
 function StreamToBase64String(AStream: TMemoryStream): string;
 var
-  LBytes: TBytes;
+  strContent: string;
 begin
-  SetLength(LBytes, AStream.Size);
+  if AStream.Size = 0 then Exit('');
+
+  // Optimization: Read directly into native string buffer, avoiding TBytes/UTF8 conversion overhead
+  SetLength(strContent, AStream.Size);
   AStream.Position := 0;
-  AStream.Read(LBytes[0], AStream.Size);
-  Result := base64.EncodeStringBase64(TEncoding.UTF8.GetString(LBytes));
+  AStream.ReadBuffer(strContent[1], AStream.Size);
+
+  Result := base64.EncodeStringBase64(strContent);
 end;
 
 function FileToStringBase64(const FileName: string; const Apagar: Boolean; out size: integer): string;
@@ -73,4 +84,3 @@ begin
 end;
 
 end.
-


### PR DESCRIPTION
💡 **What:** Optimized stream conversion functions (`Base64StreamToString`, `StringToBase64Stream`, and `StreamToBase64String`) in `tools/streamtools.pas` by using direct native string buffers instead of intermediate `TBytes` arrays via `TEncoding.UTF8`. Also cached the result of base64 encoding to prevent redundant evaluations.

🎯 **Why:** The previous implementation converted streams to strings via a slow path: allocating a `TBytes` array, performing `AStream.Read()`, converting to UTF-8 using `GetString()`, and finally decoding. Worse, `StringToBase64Stream` was calling `base64.EncodeStringBase64(...)` *twice* inline as arguments to `WriteBuffer`, forcing an expensive O(N) operation to run redundantly. Direct buffer manipulation avoids all intermediate memory allocations.

📊 **Impact:** Reduces memory overhead significantly by avoiding intermediate `TBytes` arrays. Halves the CPU cost of `StringToBase64Stream` by eliminating the redundant base64 encoding pass. Improves reliability by avoiding `TEncoding.UTF8` corruption on raw binary PDF data.

🔬 **Measurement:** Code review confirms the removal of `TBytes` arrays and the reduction of `EncodeStringBase64` calls from two to one. Manual tests and codebase compilation verifies the `ReadBuffer` string manipulation correctness.

---
*PR created automatically by Jules for task [9577118285119767520](https://jules.google.com/task/9577118285119767520) started by @macgayverarmini*