### PR TITLE
🛡️ Sentinel: [HIGH] Fix hardcoded absolute file path logging vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-26 - Hardcoded Absolute File Path Logging Vulnerability
+**Vulnerability:** A hardcoded absolute file path `C:\NFMonitor\src\bin\log_debug.txt` was used within `try...except` debugging blocks in `routes/route.acbr.nfe.pas`, coupled with a global file descriptor `var F: TextFile;`.
+**Learning:** Using global file descriptors combined with hardcoded file paths in web route handlers creates severe concurrency issues, potential denial-of-service risks (due to file locking), and exposes sensitive path structures, violating security principles for production environments.
+**Prevention:** Avoid hardcoded file paths and global file descriptors in route handlers. Use robust, configurable, and thread-safe logging mechanisms, or completely remove debugging blocks before production deployment.

--- a/routes/route.acbr.nfe.pas
+++ b/routes/route.acbr.nfe.pas
@@ -44,7 +44,6 @@ procedure PostDebugConfig(Req: THorseRequest; Res: THorseResponse; Next: TNextPr
 procedure PostNFeLote(Req: THorseRequest; Res: THorseResponse; Next: TNextProc);
 
 implementation
-var F: TextFile;
 
 
 function ExtractConfig(O: TJSONObject; const Field: string): string;
@@ -175,26 +174,14 @@ begin
   try
     Step := 'ParseJSONBody';
     O := GetJSON(Req.Body) as TJSONObject;
-    
+
     Step := 'CreateTACBRBridgeNFe';
     Ac := TACBRBridgeNFe.Create(ExtractConfig(O, RSConfigField));
     try
       Step := 'CallAcNFe';
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Chamando Ac.NFe...');
-        CloseFile(F);
-      except end;
 
       LJson := Ac.NFe(O);
 
-      try
-        AssignFile(F, 'C:\NFMonitor\src\bin\log_debug.txt');
-        if FileExists('C:\NFMonitor\src\bin\log_debug.txt') then Append(F) else Rewrite(F);
-        WriteLn(F, FormatDateTime('hh:nn:ss.zzz', Now) + ' - PostNFe: Ac.NFe retornou!');
-        CloseFile(F);
-      except end;
 
       try
         Step := 'SendResponse';


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A hardcoded absolute file path (`C:\NFMonitor\src\bin\log_debug.txt`) was used within a `try...except` debugging block in `routes/route.acbr.nfe.pas`. Crucially, this was coupled with a global file descriptor `var F: TextFile;`.
🎯 Impact: Using global file descriptors combined with hardcoded file paths in web route handlers creates severe concurrency issues and potential denial-of-service risks due to file locking when multiple requests attempt to write to the same file simultaneously. It also exposes sensitive path structures, violating security principles for production environments.
🔧 Fix: Removed the global `var F: TextFile;` declaration and the entire legacy debugging blocks using `AssignFile` targeting the hardcoded absolute path within the `PostNFe` procedure.
✅ Verification: Ran `git diff` to ensure the debugging code was cleanly removed without impacting the business logic of the route handler. Tests were attempted but skipped due to missing build tools in the environment. Manual code review confirms the concurrency flaw is eliminated.

---
*PR created automatically by Jules for task [10981530911391670341](https://jules.google.com/task/10981530911391670341) started by @macgayverarmini*